### PR TITLE
fix(topic): #895 quick wins — truthful provisional pill + no-op prefetch on cached pages

### DIFF
--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImpl.kt
@@ -124,6 +124,14 @@ class TopicRepositoryImpl @Inject constructor(
      * **No-op when the alpha `ignoreTopicCache` toggle is ON**: prefetching into Room
      * while the user explicitly asked to bypass it would re-fill the very cache they
      * want to skip, so the call returns early without hitting the network.
+     *
+     * **No-op when ANY cache row already exists** (#895 quick win 2) : the prefetch's declared
+     * purpose is warming pages never visited. Re-fetching over an existing AUTHENTICATED row is
+     * pure waste (the DAO guard below would refuse the write anyway), and over a stale ANONYMOUS
+     * row it buys nothing either — reading an anon row always triggers the authenticated refetch.
+     * The `upsertTopicPageWithPostsUnlessAuthenticated` transaction stays as the LAST line of
+     * defense against the check-then-fetch race (a concurrent authenticated fetch landing between
+     * this read and the persist).
      */
     override suspend fun prefetch(cat: Int, post: Int, page: Int) {
         val ignoreTopicCache = withContext(ioDispatcher) {
@@ -135,6 +143,10 @@ class TopicRepositoryImpl @Inject constructor(
             // very cache they asked us to skip. Cancellation semantics are preserved because we
             // do nothing.
             Log.d(LOG_TAG, "Skipped topic prefetch because ignore topic cache is enabled")
+            return
+        }
+        if (withContext(ioDispatcher) { loadFromCache(cat, post, page) } != null) {
+            Log.d(LOG_TAG, "Skipped topic prefetch: page already cached (cat=$cat post=$post page=$page)")
             return
         }
         try {

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -233,6 +233,26 @@ class TopicRepositoryImplTest {
             FetchMode.AUTHENTICATED,
             afterPrefetch!!.authMode,
         )
+        // #895 (quick win 2) — the prefetch must not even HIT the network for a cached page :
+        // its purpose is warming pages never visited. Only the auth warm-up request counts.
+        assertEquals("prefetch over a cached page must be a network no-op", 1, server.requestCount)
+    }
+
+    @Test
+    fun `prefetch skips the network when ANY row exists, even a stale ANONYMOUS one (#895)`() = runTest {
+        // Cold cache → a first anonymous prefetch lands the ANON row (1 request).
+        server.enqueue(MockResponse().setBody(fixtureHtml("topic_page_single.html")))
+        repository(now = Instant.parse("2026-04-26T18:00:00Z")).prefetch(1, 999_395, 1)
+        assertEquals(FetchMode.ANONYMOUS, dao.getTopicPage(1, 999_395, 1)!!.authMode)
+        assertEquals(1, server.requestCount)
+
+        // A much later re-prefetch (row long past the TTL) must STILL skip : re-fetching an anon
+        // row buys nothing — reading it always triggers the authenticated refetch anyway.
+        server.enqueue(MockResponse().setBody(fixtureHtml("topic_page_single.html")))
+        repository(now = Instant.parse("2026-04-26T19:30:00Z")).prefetch(1, 999_395, 1)
+
+        assertEquals("no second network request for an already-cached page", 1, server.requestCount)
+        assertEquals(FetchMode.ANONYMOUS, dao.getTopicPage(1, 999_395, 1)!!.authMode)
     }
 
     @Test

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.systemGestures
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyListState
@@ -40,6 +41,7 @@ import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
@@ -78,6 +80,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -1103,11 +1106,15 @@ internal fun TopicContent(
  * while Loading shows a plain « Chargement… ».
  */
 @Composable
-private fun topicBarPageIndicator(state: TopicUiState, loaded: TopicUiState.Mode.Loaded?): String = when {
-    // #877 — a provisional page is the instant cache emission (possibly a stale total, or an
-    // anonymous prefetch row) : keep « Chargement… » until the settled emission lands, so the
-    // pill never flashes a wrong « page X / Y ». The repository guarantees termination.
-    loaded != null && !loaded.provisional -> stringResource(
+internal fun topicBarPageIndicator(state: TopicUiState, loaded: TopicUiState.Mode.Loaded?): String = when {
+    // #895 (quick win 3, revisite du choix #877) — a PROVISIONAL page is the instant cache
+    // emission : its pagination describes EXACTLY the content on screen, so show it. Replacing
+    // known information with « Chargement… » was the residual flash the maintainer reported —
+    // the in-flight refresh is signalled by the discreet progress hairline under the bar (and
+    // the a11y description), never by blanking the pill. The #877 guarantee stands : this is the
+    // REQUESTED page's own row (never the previous page's number), and « Chargement… » remains
+    // for the pure Loading mode below.
+    loaded != null -> stringResource(
         R.string.topic_page_indicator,
         loaded.topic.page,
         loaded.topic.totalPages,
@@ -1125,6 +1132,55 @@ private fun topicBarPageIndicator(state: TopicUiState, loaded: TopicUiState.Mode
 // #772 — extra room for the title's second line (titleMedium line height) while the title is
 // expanded; the small M3 top app bar keeps a fixed container height and would clip it otherwise.
 private val TopBarExpandedTitleExtraHeight = 24.dp
+
+// #895 — the discreet under-bar refresh hairline (visible only while the displayed page is
+// provisional). The 2 dp strip is permanently reserved so it never shifts the list.
+private val TopBarRefreshHairlineHeight = 2.dp
+
+/**
+ * #895 — the top-bar page pill. Shows the pagination OF THE DISPLAYED CONTENT (provisional cache
+ * included — replacing known information with « Chargement… » was the reported flash) ; while the
+ * page is provisional, screen readers get « page X sur Y, actualisation en cours » as the
+ * equivalent of the visual hairline. No liveRegion : announcing cache-then-settled twice per
+ * navigation would be pure noise (cadrage Sol).
+ */
+@Composable
+private fun TopicBarPagePill(
+    text: String,
+    loaded: TopicUiState.Mode.Loaded?,
+    pagePickerLabel: String,
+    onOpenPagePicker: () -> Unit,
+) {
+    val refreshingLabel = loaded?.takeIf { it.provisional }?.let {
+        stringResource(
+            R.string.topic_page_indicator_refreshing_a11y,
+            it.topic.page,
+            it.topic.totalPages,
+        )
+    }
+    val base = if (loaded != null) {
+        Modifier.clickable(onClickLabel = pagePickerLabel, onClick = onOpenPagePicker)
+    } else {
+        Modifier
+    }
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelMedium,
+        color = if (loaded != null) {
+            MaterialTheme.colorScheme.primary
+        } else {
+            MaterialTheme.colorScheme.onSurfaceVariant
+        },
+        modifier = if (refreshingLabel != null) {
+            base.semantics { contentDescription = refreshingLabel }
+        } else {
+            base
+        },
+    )
+}
+
+/** #895 — test tag of the provisional-refresh hairline under the top bar. */
+const val TOPIC_REFRESH_HAIRLINE_TAG = "topic_refresh_hairline"
 
 /**
  * #285/#284 + Chantier C (#546) — the topic top app bar (title + page counter + back) plus the
@@ -1200,19 +1256,11 @@ internal fun TopicTopBar(
                             )
                             .semantics { stateDescription = titleStateLabel },
                     )
-                    Text(
+                    TopicBarPagePill(
                         text = barPageIndicator,
-                        style = MaterialTheme.typography.labelMedium,
-                        color = if (loaded != null) {
-                            MaterialTheme.colorScheme.primary
-                        } else {
-                            MaterialTheme.colorScheme.onSurfaceVariant
-                        },
-                        modifier = if (loaded != null) {
-                            Modifier.clickable(onClickLabel = pagePickerLabel) { pagePickerOpen = true }
-                        } else {
-                            Modifier
-                        },
+                        loaded = loaded,
+                        pagePickerLabel = pagePickerLabel,
+                        onOpenPagePicker = { pagePickerOpen = true },
                     )
                 }
             },
@@ -1251,6 +1299,24 @@ internal fun TopicTopBar(
             },
             scrollBehavior = scrollBehavior,
         )
+        // #895 (quick win 3) — discreet refresh signal : a 2 dp hairline under the bar while the
+        // displayed page is provisional (cache on screen, authenticated refresh in flight). The
+        // strip is ALWAYS reserved (transparent when settled) so its appearance never shifts the
+        // list below — this PR exists to remove flashes, not to add one.
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(TopBarRefreshHairlineHeight),
+        ) {
+            if (loaded?.provisional == true) {
+                LinearProgressIndicator(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(TopBarRefreshHairlineHeight)
+                        .testTag(TOPIC_REFRESH_HAIRLINE_TAG),
+                )
+            }
+        }
         if (state.search.isActive) {
             TopicSearchBar(search = state.search, onIntent = onIntent)
         }

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -57,6 +57,8 @@
     <string name="topic_search_prev_result">Résultat précédent</string>
     <string name="topic_search_next_result">Résultat suivant</string>
     <string name="topic_search_results_end">Aucun résultat suivant</string>
+    <!-- #895 — description a11y de la pilule quand la page affichée (cache) se rafraîchit. -->
+    <string name="topic_page_indicator_refreshing_a11y">Page %1$d sur %2$d, actualisation en cours</string>
     <string name="topic_error_title">Erreur de chargement</string>
     <string name="topic_error_body">Impossible d’ouvrir la page %1$d.\n\n%2$s</string>
     <string name="topic_post_index_prefix">#%1$d • </string>

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicTopBarProvisionalPillTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicTopBarProvisionalPillTest.kt
@@ -1,0 +1,108 @@
+package fr.forumhfr.redface2.feature.topic
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import fr.forumhfr.redface2.core.model.Topic
+import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * #895 (quick win 3) — the top-bar pill describes the DISPLAYED content, provisional cache
+ * included : « page X / Y » with the discreet refresh hairline + the « actualisation en cours »
+ * a11y description while the refresh is in flight, the same pagination without them once
+ * settled, and « Chargement… » ONLY in pure Loading (no content on screen — the #877 guarantee).
+ * The pill string goes through the REAL [topicBarPageIndicator] derivation, not a hand-fed
+ * stand-in.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h780dp-xxhdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@OptIn(ExperimentalTestApi::class, ExperimentalMaterial3Api::class)
+class TopicTopBarProvisionalPillTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `a provisional page shows its own pagination, the hairline and the refreshing description`() {
+        setBar(sampleState(mode = loadedMode(provisional = true)))
+
+        composeTestRule.onNodeWithText("page 3 / 10").assertExists()
+        composeTestRule.onNodeWithTag(TOPIC_REFRESH_HAIRLINE_TAG, useUnmergedTree = true).assertExists()
+        composeTestRule
+            .onNodeWithContentDescription("Page 3 sur 10, actualisation en cours")
+            .assertExists()
+    }
+
+    @Test
+    fun `a settled page keeps the pagination and drops the hairline and the description`() {
+        setBar(sampleState(mode = loadedMode(provisional = false)))
+
+        composeTestRule.onNodeWithText("page 3 / 10").assertExists()
+        composeTestRule
+            .onNodeWithTag(TOPIC_REFRESH_HAIRLINE_TAG, useUnmergedTree = true)
+            .assertDoesNotExist()
+        composeTestRule
+            .onNodeWithContentDescription("Page 3 sur 10, actualisation en cours")
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `pure Loading keeps the Chargement pill and no hairline`() {
+        setBar(sampleState(mode = TopicUiState.Mode.Loading))
+
+        composeTestRule.onNodeWithText("Chargement…").assertExists()
+        composeTestRule
+            .onNodeWithTag(TOPIC_REFRESH_HAIRLINE_TAG, useUnmergedTree = true)
+            .assertDoesNotExist()
+    }
+
+    private fun setBar(state: TopicUiState) {
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                val loaded = state.mode as? TopicUiState.Mode.Loaded
+                TopicTopBar(
+                    state = state,
+                    barTitle = "Un sujet",
+                    barPageIndicator = topicBarPageIndicator(state, loaded),
+                    backLabel = "Retour",
+                    scrollBehavior = null,
+                    onBack = {},
+                    onIntent = {},
+                    loaded = loaded,
+                )
+            }
+        }
+    }
+
+    private fun loadedMode(provisional: Boolean): TopicUiState.Mode.Loaded =
+        TopicUiState.Mode.Loaded(
+            topic = Topic(
+                cat = 23,
+                post = 35421,
+                subcat = 550,
+                title = "Un sujet",
+                posts = emptyList(),
+                page = 3,
+                totalPages = 10,
+                isFirstPostOwner = false,
+                poll = null,
+            ),
+            provisional = provisional,
+        )
+
+    private fun sampleState(mode: TopicUiState.Mode): TopicUiState = TopicUiState(
+        request = TopicRequest(cat = 23, post = 35421, page = 3, scrollTo = null),
+        mode = mode,
+        availablePages = emptyList(),
+    )
+}


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

**Étapes 1-3 du plan #895** (l'étape 4 — pagination intra-topic dans un même ViewModel, le correctif de fond — suit dans une PR dédiée après cadrage).

## Changements

- **Pilule fidèle au contenu affiché** : en `provisional` (cache à l'écran, refresh en vol) la pilule affiche « page X / Y » du contenu — remplacer une information connue par « Chargement… » pendant tout l'aller-retour réseau était le flash résiduel remonté. Le `Loading` pur garde « Chargement… » (la garantie #877 tient : la row provisional est celle de la page DEMANDÉE, jamais le numéro de la page précédente).
- **Signal de refresh discret** : hairline de 2 dp sous la barre pendant le provisional — bande réservée en permanence (zéro décalage de layout) ; équivalent a11y « page X sur Y, actualisation en cours » sans liveRegion.
- **Prefetch no-op réseau si la page est en cache** (quelle que soit la row) : son but est de chauffer les pages jamais visitées ; re-fetch d'une row AUTH = refusé par la garde DAO de toute façon (contrat déjà épinglé par `TopicDaoTest`), re-fetch d'une row ANON périmée n'apporte rien (sa lecture re-fetche authentifié quoi qu'il arrive). La transaction `UnlessAuthenticated` reste la défense anti-course.

## Validation

- Canonique complète verte ; tests repo : prefetch = 0 requête réseau sur page cachée (auth ET anon périmée) + assertions anti-écrasement existantes conservées.
- Gate Codex + dogfood émulateur avant merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqxgKdydUwQEqqJm6rkGUh
