### PR TITLE
chore(release): 0.27.3 — #895 quick wins

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,15 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.27.3` — `internal` (dev) — 2026-07-12
+
+**Quick wins zéro-flash** (#895, PR #899 — premier lot du chantier « zéro flash au changement de page » ; le fond, pagination intra-topic dans un même ViewModel, suit dans un lot dédié).
+
+### Vue Topic — changement de page
+- **La pilule de la barre dit la vérité** : une page servie du cache pendant son actualisation affiche « page X / Y » (le contenu réellement à l'écran) au lieu de « Chargement… » ; « Chargement… » est réservé au vrai chargement sans contenu.
+- **Signal d'actualisation discret** : fine barre de progression (2 dp) sous la top bar pendant l'actualisation d'une page en cache — bande toujours réservée, aucun décalage de mise en page ; annonce d'accessibilité « actualisation en cours » sur la pilule.
+- **Prefetch sans réseau inutile** : le préchargement des pages voisines ne refait plus de requête quand la page est déjà en cache (et n'écrase jamais une version authentifiée — garde couverte par tests).
+
 ## `0.27.2` — `internal` (dev) — 2026-07-12
 
 **Recherche intra-topic v2** (#894, retours XaTriX sur 0.27.1 — contrat `transsearch` re-vérifié live, cadrage + gates Codex, dogfoods sur le serveur réel).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.27.2"
+        versionName = "0.27.3"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,5 +1,5 @@
-Redface 2 v0.27.2 — dev.
+Redface 2 v0.27.3 — dev.
 
-- In-topic search: non-filtered author search works again.
-- Searches start from the current page (site parity); new "Search from the beginning" option.
-- Filtered results: "Show next results" button when HFR truncates the list (~200).
+- Page changes: the top bar shows "page X / Y" for the on-screen content instead of "Loading…" when the page comes from cache.
+- Thin progress hairline under the top bar while a cached page refreshes, with no layout shift.
+- Neighbor-page prefetch no longer hits the network when the page is already cached.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,5 +1,5 @@
-Redface 2 v0.27.2 — dev.
+Redface 2 v0.27.3 — dev.
 
-- Recherche dans le sujet : la recherche par pseudo sans filtre refonctionne.
-- La recherche part de la page courante (comme le site) ; option « Chercher depuis le début du sujet ».
-- Résultats filtrés : bouton « Afficher les résultats suivants » quand HFR tronque la liste (~200).
+- Changement de page : la barre affiche « page X / Y » du contenu à l'écran au lieu de « Chargement… » quand la page vient du cache.
+- Fine barre de progression sous la top bar pendant l'actualisation, sans décalage de mise en page.
+- Préchargement des pages voisines sans requête réseau inutile quand la page est déjà en cache.


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Bump `versionName` 0.27.2 → 0.27.3 + entrée CHANGELOG + whatsnew fr/en (version en 1re ligne, garde whatsnew-freshness).

Contenu de la release : PR #899 (quick wins #895 — pilule véridique « page X / Y » sur les pages en cache, hairline d'actualisation 2 dp sans layout shift, prefetch no-op si cache présent).

Edit mécanique de release — exception à la cadence Codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqxgKdydUwQEqqJm6rkGUh