### PR TITLE
fix(editor): render small wiki smileys at native size in the picker (#871)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerSheet.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerSheet.kt
@@ -37,12 +37,19 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import coil3.SingletonImageLoader
 import coil3.compose.AsyncImage
+import coil3.compose.LocalPlatformContext
 import fr.forumhfr.redface2.core.model.BUILTIN_HFR_SMILEYS
 import fr.forumhfr.redface2.core.model.EditorSmiley
 import fr.forumhfr.redface2.core.model.EditorSmileySource
+import fr.forumhfr.redface2.core.ui.post.LocalIntrinsicMediaSizeCache
+import fr.forumhfr.redface2.core.ui.post.PixelSize
+import fr.forumhfr.redface2.core.ui.post.intrinsicSmileyDisplaySize
+import fr.forumhfr.redface2.core.ui.post.measureAndCacheIntrinsicMediaSize
 
 /**
  * Phase 2F-B (#11 partial) — bottom-sheet smiley picker. Promoted from `:feature:editor`
@@ -217,6 +224,25 @@ private fun SmileyGrid(items: List<EditorSmiley>, onSmileyClicked: (String) -> U
 @Composable
 private fun SmileyCell(smiley: EditorSmiley, onClick: () -> Unit) {
     val description = stringResource(R.string.editor_smiley_insert_description, smiley.token)
+    // #871 — persos reuse the posts' intrinsic-measurement pipeline (#175) : a bounded Coil probe
+    // shares the SingletonImageLoader caches with the rendering AsyncImage below (no double
+    // fetch), and the process-wide URL cache means a smiley measured in the picker is already
+    // sized when it later renders inside a post — and vice versa. Builtins are never measured
+    // (known ~16 px sprites, same contract as the posts). The cache read is a tracked snapshot
+    // read : the cell recomposes at the measured size the moment the probe lands.
+    val sizeCache = LocalIntrinsicMediaSizeCache.current
+    val platformContext = LocalPlatformContext.current
+    if (smiley.source == EditorSmileySource.WIKI) {
+        LaunchedEffect(smiley.imageUrl) {
+            measureAndCacheIntrinsicMediaSize(
+                url = smiley.imageUrl,
+                cache = sizeCache,
+                context = platformContext,
+                imageLoader = SingletonImageLoader.get(platformContext),
+            )
+        }
+    }
+    val measuredPx = if (smiley.source == EditorSmileySource.WIKI) sizeCache.get(smiley.imageUrl) else null
     Box(
         modifier = Modifier
             // #236 — 48.dp keeps the Material minimum touch target while the grid gets denser.
@@ -234,10 +260,12 @@ private fun SmileyCell(smiley: EditorSmiley, onClick: () -> Unit) {
             // are ~15 px sprites rendered near-native, persos are richer images that deserve
             // most of the cell. The single 30.dp of #236 made builtins big+blurry and persos
             // cramped at once. ContentScale.Fit preserves aspect ratios in both cases.
-            modifier = Modifier.size(smileyCellImageSize(smiley.source)),
+            // #871 — the perso box is the measured no-upscale size, so Fit never stretches a
+            // small sprite past its native scale ; the parent Box centres it in the cell.
+            modifier = Modifier.size(smileyCellImageSize(smiley.source, measuredPx)),
             contentScale = ContentScale.Fit,
             // Pixel-art builtins stay crisp unfiltered ; persos (photos, rich art, GIF frames)
-            // look better bilinear-filtered at their mild upscale.
+            // look better bilinear-filtered when the cell cap scales them down.
             filterQuality = when (smiley.source) {
                 EditorSmileySource.BUILTIN -> FilterQuality.None
                 EditorSmileySource.WIKI -> FilterQuality.Low
@@ -248,10 +276,34 @@ private fun SmileyCell(smiley: EditorSmiley, onClick: () -> Unit) {
 
 /**
  * #816 — the picker's per-source thumbnail size : builtins near their ~15 px native scale,
- * persos filling most of the 48.dp cell, mirroring their relative sizes in a rendered post.
- * Pure — pinned by unit test.
+ * persos mirroring their relative size in a rendered post.
+ *
+ * #871 (thibw) — a MEASURED perso applies the posts' no-upscale + cap policy (#175,
+ * [intrinsicSmileyDisplaySize]) at the forum scale (1 native px ≈ 1 dp, the picker analogue of
+ * the renderer's `px → sp`) : a sprite smaller than the [WIKI_CELL_IMAGE_SIZE_DP] cell renders
+ * at its crisp native size (centred by the cell), a larger one shrinks to fit, aspect ratio
+ * preserved. An UNMEASURED perso (cold cache, or measurement failure — dead URL) keeps the
+ * pre-#871 cell-filling square as provisional fallback. Pure — pinned by unit test.
  */
-internal fun smileyCellImageSize(source: EditorSmileySource): Dp = when (source) {
-    EditorSmileySource.BUILTIN -> 20.dp
-    EditorSmileySource.WIKI -> 44.dp
+internal fun smileyCellImageSize(source: EditorSmileySource, measuredPx: IntSize?): DpSize = when (source) {
+    EditorSmileySource.BUILTIN -> DpSize(20.dp, 20.dp)
+    EditorSmileySource.WIKI -> {
+        val nativePx = measuredPx?.takeIf { it.width > 0 && it.height > 0 }
+        if (nativePx == null) {
+            DpSize(WIKI_CELL_IMAGE_SIZE_DP.dp, WIKI_CELL_IMAGE_SIZE_DP.dp)
+        } else {
+            val display = intrinsicSmileyDisplaySize(
+                nativePx = PixelSize(nativePx.width, nativePx.height),
+                maxWidthSp = WIKI_CELL_IMAGE_SIZE_DP,
+                maxHeightSp = WIKI_CELL_IMAGE_SIZE_DP,
+            )
+            DpSize(display.width.dp, display.height.dp)
+        }
+    }
 }
+
+/**
+ * #816/#871 — the perso thumbnail slot inside the 48.dp cell : the fixed size of an unmeasured
+ * perso, and the per-axis cap of a measured one.
+ */
+internal const val WIKI_CELL_IMAGE_SIZE_DP = 44

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyCellImageSizeTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyCellImageSizeTest.kt
@@ -1,5 +1,7 @@
 package fr.forumhfr.redface2.core.ui.editor
 
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import fr.forumhfr.redface2.core.model.EditorSmileySource
 import org.junit.Assert.assertEquals
@@ -7,18 +9,49 @@ import org.junit.Test
 
 /**
  * #816 (thibw) — the picker mirrors HFR's real scale contrast : builtin sprites near-native
- * (small), perso smileys filling most of the 48.dp cell (large). One uniform size cannot do
- * both — this pins the per-source contract.
+ * (small), perso smileys getting most of the 48.dp cell. One uniform size cannot do both —
+ * this pins the per-source contract.
+ *
+ * #871 (thibw) — a measured perso follows the posts' no-upscale + cap policy (#175) : native
+ * size at the forum scale (1 px ≈ 1 dp) when it fits the cell, scaled down when it does not,
+ * NEVER stretched past native (the 0.26.3 "small wiki smileys are zoomed and blurry" report).
  */
 class SmileyCellImageSizeTest {
 
     @Test
     fun `builtin sprites render near their native scale`() {
-        assertEquals(20.dp, smileyCellImageSize(EditorSmileySource.BUILTIN))
+        assertEquals(DpSize(20.dp, 20.dp), smileyCellImageSize(EditorSmileySource.BUILTIN, measuredPx = null))
     }
 
     @Test
-    fun `perso smileys fill most of the cell`() {
-        assertEquals(44.dp, smileyCellImageSize(EditorSmileySource.WIKI))
+    fun `unmeasured perso falls back to filling most of the cell`() {
+        assertEquals(DpSize(44.dp, 44.dp), smileyCellImageSize(EditorSmileySource.WIKI, measuredPx = null))
+    }
+
+    @Test
+    fun `small measured perso keeps its native size — NO upscale (#871)`() {
+        assertEquals(DpSize(28.dp, 28.dp), smileyCellImageSize(EditorSmileySource.WIKI, IntSize(28, 28)))
+        assertEquals(DpSize(15.dp, 15.dp), smileyCellImageSize(EditorSmileySource.WIKI, IntSize(15, 15)))
+    }
+
+    @Test
+    fun `perso exactly at the cap passes through untouched`() {
+        assertEquals(DpSize(44.dp, 44.dp), smileyCellImageSize(EditorSmileySource.WIKI, IntSize(44, 44)))
+    }
+
+    @Test
+    fun `oversized perso is capped down to the cell, aspect ratio preserved`() {
+        // Dominant 70×50 corpus size : scale 44/70 ≈ 0.629 → 44×31.
+        assertEquals(DpSize(44.dp, 31.dp), smileyCellImageSize(EditorSmileySource.WIKI, IntSize(70, 50)))
+    }
+
+    @Test
+    fun `degenerate measurement falls back to the cell-filling square`() {
+        assertEquals(DpSize(44.dp, 44.dp), smileyCellImageSize(EditorSmileySource.WIKI, IntSize(0, 50)))
+    }
+
+    @Test
+    fun `builtin ignores any measurement (never measured in production)`() {
+        assertEquals(DpSize(20.dp, 20.dp), smileyCellImageSize(EditorSmileySource.BUILTIN, IntSize(70, 50)))
     }
 }


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Summary

Suivi du retour testeur sur #816 (thibw, fil DEV #2790796 ; qwazer #2790801) : dans l'onglet Wiki du sélecteur de smileys, les persos plus petits que la vignette de 44 dp étaient étirés par `ContentScale.Fit` et devenaient flous.

Le fix réutilise le pipeline intrinsèque des posts (#175) au lieu d'inventer une nouvelle approche : mesure de la taille native via la sonde Coil bornée (`measureAndCacheIntrinsicMediaSize`, caches `SingletonImageLoader` + cache d'URL process-wide partagés avec le rendu des posts), puis politique no-upscale + cap (`intrinsicSmileyDisplaySize`) à l'échelle forum (1 px natif ≈ 1 dp) : un petit perso s'affiche net à sa taille native, centré dans la cellule ; un grand rétrécit toujours pour tenir dans les 44 dp, ratio préservé.

## Linked Issue

- Closes #871

## Changes

- `SmileyPickerSheet.kt` — `SmileyCell` mesure les persos (WIKI uniquement) via le pipeline #175 ; `smileyCellImageSize` devient `(source, measuredPx) -> DpSize` avec no-upscale + cap à 44 dp. Fallback inchangé (carré 44 dp) tant que la mesure n'a pas atterri ou en cas d'échec (URL morte). Builtins strictement inchangés (20 dp quasi natif, `FilterQuality.None`).
- `SmileyCellImageSizeTest.kt` — étendu : no-upscale (28×28 et 15×15 restent natifs), passage exact au cap (44×44), réduction avec ratio (70×50 → 44×31), fallback non mesuré / mesure dégénérée, builtin insensible à la mesure. 7 tests.

## Validation Run

- [x] Branché depuis `origin/dev` frais (75d1a7ed), worktree isolé
- [x] `./scripts/docker-dev.sh ./gradlew :core:ui:testDebugUnitTest detektAll --console=plain --no-daemon` — **BUILD SUCCESSFUL** (exit 0) ; `:core:ui:testDebugUnitTest` : 355 tests, 0 failure, 0 error (dont les 7 de `SmileyCellImageSizeTest`)
- [ ] `:app:assembleProdDebug` non lancé localement (contrainte RAM partagée) — la CI de la PR fait foi
- [ ] Pas de fixture ajoutée, pas de bump `versionName`

## Docs / Specs Impact

- [x] Aucun

## Review

- [ ] Review Codex non jointe (fix ciblé réutilisant un pattern existant) — la CI + review valident

## AI Attribution

> Action par Claude Fable 5 (demandée par @XaTriX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqxgKdydUwQEqqJm6rkGUh