### PR TITLE
fix(editor): restored smiley search reopens with the caret at the end (#901)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerSheet.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerSheet.kt
@@ -37,6 +37,8 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
@@ -146,10 +148,28 @@ private fun WikiTabContent(
     LaunchedEffect(Unit) {
         searchFocus.requestFocus()
     }
+    // #901 — the field owns a TextFieldValue seeded from the (possibly #824-restored) query
+    // with the caret at the END, so a restored word can be completed or erased right away.
+    // The String overload of OutlinedTextField builds its internal TextFieldValue with
+    // selection = TextRange(0), which put the restored caret at the START of the word.
+    // Seeded ONCE (no resync from state.query) : while this tab is composed the only query
+    // writer is this very field (the #824 restore happens in open(), atomically with the
+    // Hidden→Open transition that composes the sheet), and a composition-time resync would
+    // race the collectAsStateWithLifecycle echo of onQueryChange, clobbering fast typing.
+    var fieldValue by remember {
+        mutableStateOf(TextFieldValue(text = state.query, selection = TextRange(state.query.length)))
+    }
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         OutlinedTextField(
-            value = state.query,
-            onValueChange = onQueryChange,
+            value = fieldValue,
+            onValueChange = { newValue ->
+                // The TextFieldValue overload also fires on caret/selection moves : only a
+                // text change may reach the controller, whose onQueryChanged cancels the
+                // in-flight search — a mid-word tap must not kill a pending debounce.
+                val textChanged = newValue.text != fieldValue.text
+                fieldValue = newValue
+                if (textChanged) onQueryChange(newValue.text)
+            },
             singleLine = true,
             label = { Text(stringResource(R.string.editor_smiley_search_label)) },
             modifier = Modifier

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerSheetRestoreCaretTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerSheetRestoreCaretTest.kt
@@ -1,0 +1,103 @@
+package fr.forumhfr.redface2.core.ui.editor
+
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.text.TextRange
+import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * #901 — the #824 restore-on-reopen must land with the caret at the END of the restored
+ * word, so the user can either complete it or erase it in one gesture (tinc/nicko consensus
+ * on the DEV thread). The regression came from the String overload of [OutlinedTextField],
+ * whose internal TextFieldValue defaults its selection to TextRange(0).
+ *
+ * The reopen is driven through a real [SmileyPickerController] (open → type → dismiss →
+ * open), exactly the sequence of an insertion or an accidental swipe-down ; the sheet is
+ * then composed from the restored state, like every host does. The search job armed by
+ * typing stays parked on a [StandardTestDispatcher] (never advanced) and is cancelled by
+ * dismiss(), so no fake network resolution can interfere.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h780dp-xxhdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class SmileyPickerSheetRestoreCaretTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private fun reopenedController(query: String): SmileyPickerController {
+        val controller = SmileyPickerController(
+            scope = CoroutineScope(StandardTestDispatcher()),
+            searchWiki = { _, _ -> emptyList() },
+        )
+        controller.open()
+        controller.onQueryChanged(query)
+        controller.dismiss()
+        controller.open()
+        return controller
+    }
+
+    private fun composeSheet(controller: SmileyPickerController) {
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                val state by controller.state.collectAsState()
+                (state as? SmileyPickerState.Open)?.let { open ->
+                    SmileyPickerSheet(
+                        state = open,
+                        onDismiss = controller::dismiss,
+                        onQueryChange = controller::onQueryChanged,
+                        onSmileyClicked = {},
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `reopen restores the query with the caret at the end`() {
+        composeSheet(reopenedController("jap"))
+
+        // The restored non-empty query auto-selects the Wiki tab (#824), whose search field
+        // is the only node with a set-text action in the sheet.
+        val node = composeTestRule.onNode(hasSetTextAction()).fetchSemanticsNode()
+        assertEquals("jap", node.config[SemanticsProperties.EditableText].text)
+        assertEquals(
+            "the caret must sit at the END of the restored word",
+            TextRange(3),
+            node.config[SemanticsProperties.TextSelectionRange],
+        )
+    }
+
+    @Test
+    fun `typing after a reopen appends to the restored word`() {
+        val controller = reopenedController("jap")
+        composeSheet(controller)
+
+        // Functional proof of the caret position : the committed character lands AFTER the
+        // restored word (a caret at 0 would have produced "ojap"), and the controller sees
+        // the appended query.
+        composeTestRule.onNode(hasSetTextAction()).performTextInput("o")
+
+        val node = composeTestRule.onNode(hasSetTextAction()).fetchSemanticsNode()
+        assertEquals("japo", node.config[SemanticsProperties.EditableText].text)
+        assertEquals(
+            "japo",
+            (controller.state.value as SmileyPickerState.Open).query,
+        )
+    }
+}


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Fix

À la réouverture du panneau smileys, la recherche restaurée (#824) revenait avec le curseur au **début** du mot : l'overload `String` de `OutlinedTextField` construit son `TextFieldValue` interne avec `selection = TextRange(0)`. Le champ de recherche du tab Wiki possède désormais son `TextFieldValue`, seedé depuis la query restaurée avec `selection = TextRange(text.length)` — le mot est conservé (comportement #824 inchangé, cas d'usage nicko) et le curseur atterrit à la **fin** (consensus tinc #2791004 / nicko #2790994) : on peut compléter ou effacer en un geste.

Détails :
- **Seed unique, pas de resync depuis `state.query`** : pendant que le tab Wiki est composé, la seule source d'écriture de la query est le champ lui-même (la restauration #824 se fait dans `open()`, atomiquement avec la transition Hidden→Open qui compose le sheet) ; un resync en composition raserait la frappe rapide via l'écho `collectAsStateWithLifecycle`.
- **Garde sur les déplacements de curseur** : l'overload `TextFieldValue` déclenche aussi `onValueChange` sur les changements de sélection ; seuls les changements de texte remontent au contrôleur (dont `onQueryChanged` annule la recherche en vol) — un tap au milieu du mot ne tue plus un debounce en cours. Contrat contrôleur identique à l'overload String d'avant.
- **Les 4 surfaces couvertes** : éditeur de post, création de topic, MP compose/réponse passent toutes par le même `SmileyPickerSheet` de `:core:ui`.

## Tests

Nouveau `SmileyPickerSheetRestoreCaretTest` (Robolectric/Compose, `:core:ui`) — pilote un vrai `SmileyPickerController` (open → frappe → dismiss → reopen) puis compose le sheet depuis l'état restauré, comme les hosts :
- la query restaurée est présente et `TextSelectionRange == TextRange(3)` (fin du mot) ;
- preuve fonctionnelle : `performTextInput("o")` sur « jap » restauré produit « japo » (un curseur à 0 aurait donné « ojap »), et le contrôleur voit « japo ».

Validation locale (`scripts/docker-dev.sh`, exécutée) :
- `:core:ui:testDebugUnitTest` : **BUILD SUCCESSFUL** (6m46s) — la nouvelle classe : tests=2, failures=0, errors=0 ;
- `detektAll` : **BUILD SUCCESSFUL** (53s).

Closes #901

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqxgKdydUwQEqqJm6rkGUh