### PR TITLE
chore(release): 0.27.4 — duo picker smileys

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,14 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.27.4` — `internal` (dev) — 2026-07-12
+
+**Duo picker smileys** (retours tinc/nicko du jour sur le fil DEV — fixes livrés en parallèle par sub-agents, gates Codex GO).
+
+### Éditeur — sélecteur de smileys
+- **Fini les petits smileys flous** (#871, PR #903) : les persos plus petits que la cellule s'affichent à leur taille intrinsèque (même pipeline de mesure que le rendu des posts, #175), jamais étirés ; cap 44 dp conservé, builtins inchangés.
+- **Curseur en fin de mot** (#901, PR #904) : la recherche restaurée à la réouverture du panneau (#824) garde le terme et place le curseur à la FIN — effacer ou compléter est immédiat.
+
 ## `0.27.3` — `internal` (dev) — 2026-07-12
 
 **Quick wins zéro-flash** (#895, PR #899 — premier lot du chantier « zéro flash au changement de page » ; le fond, pagination intra-topic dans un même ViewModel, suit dans un lot dédié).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.27.3"
+        versionName = "0.27.4"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,5 +1,4 @@
-Redface 2 v0.27.3 — dev.
+Redface 2 v0.27.4 — dev.
 
-- Page changes: the top bar shows "page X / Y" for the on-screen content instead of "Loading…" when the page comes from cache.
-- Thin progress hairline under the top bar while a cached page refreshes, with no layout shift.
-- Neighbor-page prefetch no longer hits the network when the page is already cached.
+- Smiley picker: small custom smileys render at their native size, never upscaled and blurry.
+- The picker search reopens with the caret at the end of the preserved word.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,5 +1,4 @@
-Redface 2 v0.27.3 — dev.
+Redface 2 v0.27.4 — dev.
 
-- Changement de page : la barre affiche « page X / Y » du contenu à l'écran au lieu de « Chargement… » quand la page vient du cache.
-- Fine barre de progression sous la top bar pendant l'actualisation, sans décalage de mise en page.
-- Préchargement des pages voisines sans requête réseau inutile quand la page est déjà en cache.
+- Sélecteur de smileys : les petits smileys perso s'affichent à leur taille réelle, plus jamais agrandis et flous.
+- La recherche du panneau smileys rouvre avec le curseur à la fin du mot conservé.


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Bump `versionName` 0.27.3 → 0.27.4 + CHANGELOG + whatsnew fr/en (version en 1re ligne).

Contenu : PR #903 (#871 — no-upscale des persos dans le picker) + PR #904 (#901 — curseur en fin de mot restauré). Edit mécanique de release — exception à la cadence Codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqxgKdydUwQEqqJm6rkGUh