### PR TITLE
chore(release): 0.28.0 — pagination in-VM, zéro flash inter-pages (#895)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,18 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.28.0` — `internal` (dev) — 2026-07-12
+
+**Zéro flash au changement de page** (#895 étapes 4-5, PRs #905/#907/#908 — le fond du chantier, après les quick wins de 0.27.3).
+
+### Vue topic — moteur de pagination in-ViewModel
+- **Plus aucun flash au changement de page** : la pagination vit dans un seul écran retenu (une seule entrée de navigation pour tout le topic) — plus de squelette plein écran ni de barre recréée entre deux pages ; le squelette ne reste que pour une page jamais visitée.
+- **Revisite instantanée** : les 5 dernières pages lues sont gardées en mémoire — y revenir est immédiat, à la position exacte où on les avait laissées.
+- **Retour de citation fidèle** (#782 renforcé) : après « aller au message cité », le retour ramène à la position exacte du tap, même en chaîne ; un changement de page manuel réinitialise la chaîne (comportement navigateur), un 2e retour sort du topic.
+- **Landing « page précédente » conservé** (#412) : reculer d'une page atterrit en bas (sens de lecture), sauf position déjà connue pour cette page.
+- Post-submit : la publication rafraîchit la bonne page dans le MÊME écran (débordement #226 géré en interne, plus de re-navigation) ; la position de lecture survit à la mort de process (page + ancre).
+- Nettoyage : transition instantanée topic→topic supprimée (code mort de l'ère « une route par page »).
+
 ## `0.27.4` — `internal` (dev) — 2026-07-12
 
 **Duo picker smileys** (retours tinc/nicko du jour sur le fil DEV — fixes livrés en parallèle par sub-agents, gates Codex GO).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.27.4"
+        versionName = "0.28.0"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,4 +1,4 @@
-Redface 2 v0.27.4 — dev.
+Redface 2 v0.28.0 — dev.
 
-- Smiley picker: small custom smileys render at their native size, never upscaled and blurry.
-- The picker search reopens with the caret at the end of the preserved word.
+- Page changes no longer flash: the topic is one retained screen, and already-read pages reopen instantly at your exact position.
+- Back after "go to quoted post" returns exactly where you left, even chained.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,4 +1,4 @@
-Redface 2 v0.27.4 — dev.
+Redface 2 v0.28.0 — dev.
 
-- Sélecteur de smileys : les petits smileys perso s'affichent à leur taille réelle, plus jamais agrandis et flous.
-- La recherche du panneau smileys rouvre avec le curseur à la fin du mot conservé.
+- Plus aucun flash au changement de page : le topic est un seul écran, les pages déjà lues se rouvrent instantanément à la position exacte.
+- Le retour après « aller au message cité » revient exactement au point de départ, même en chaîne.


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaaT)

Bump `versionName` 0.27.4 → **0.28.0** (mineur : changement d'architecture de la vue topic, chantier #895 clos) + entrée CHANGELOG + whatsnew fr/en.

Contenu : PRs #905 (moteur, 7 gates), #907 (bascule navigation, 4 gates), #908 (cleanup). Dogfood émulateur zéro-flash validé.

Dispatch `channel=dev` après merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqxgKdydUwQEqqJm6rkGUh