### PR TITLE
chore(release): 0.28.1 — stale-while-switching (#910)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,15 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.28.1` — `internal` (dev) — 2026-07-13
+
+**Stale-while-switching** (#910, PR #911 — retour immédiat de XaTriX sur la 0.28.0 : « ça saute/flash toujours sur une page non connue »).
+
+### Vue topic
+- **Plus de squelette flashé sur un changement de page rapide** : la page quittée reste affichée (hairline discrète) pendant que la nouvelle charge ; le squelette n'apparaît que si le chargement dépasse ~250 ms. Une page en cache Room (session antérieure) bascule sans aucun flash.
+- La pilule ne dit plus jamais « Chargement… » par-dessus un contenu affiché ; la barre (loupe, repli auto-hide, titre) ne change plus d'état pendant le chargement d'un switch.
+- Gardes : un switch échoué affiche l'erreur (jamais un état figé) ; pull-to-refresh inactif pendant la transition.
+
 ## `0.28.0` — `internal` (dev) — 2026-07-12
 
 **Zéro flash au changement de page** (#895 étapes 4-5, PRs #905/#907/#908 — le fond du chantier, après les quick wins de 0.27.3).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.28.0"
+        versionName = "0.28.1"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,4 +1,3 @@
-Redface 2 v0.28.0 — dev.
+Redface 2 v0.28.1 — dev.
 
-- Page changes no longer flash: the topic is one retained screen, and already-read pages reopen instantly at your exact position.
-- Back after "go to quoted post" returns exactly where you left, even chained.
+- No more skeleton flash on fast page changes: the previous page stays on screen while the new one loads (the skeleton only appears past 250 ms).

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,4 +1,3 @@
-Redface 2 v0.28.0 — dev.
+Redface 2 v0.28.1 — dev.
 
-- Plus aucun flash au changement de page : le topic est un seul écran, les pages déjà lues se rouvrent instantanément à la position exacte.
-- Le retour après « aller au message cité » revient exactement au point de départ, même en chaîne.
+- Plus de squelette flashé sur un changement de page rapide : l'ancienne page reste affichée pendant que la nouvelle charge (le squelette n'apparaît qu'au-delà de 250 ms).


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Bump 0.28.0 → **0.28.1** (patch, politique A) + CHANGELOG + whatsnew. Contenu : PR #911 (cadrage + 2 gates Sol GO). Dispatch `channel=dev` après merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqxgKdydUwQEqqJm6rkGUh