### PR TITLE
fix(topic): #913 closeSearch recharge la page canonique après un takeover de transition

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -1391,13 +1391,23 @@ class TopicViewModel @AssistedInject constructor(
      * actually applied (`status == Done`) to avoid a needless refetch on a cancel-before-submit.
      */
     private fun closeSearch() {
-        val hadResults = _state.value.search.status == TopicSearchStatus.Done
+        val current = _state.value
+        val hadResults = current.search.status == TopicSearchStatus.Done
+        // #913 (verdict Sol loupe/#910) — a search submitted during a page transition took over
+        // the switch load ; closing WITHOUT results used to skip the reload, leaving the departed
+        // page displayed while the canonical page is the target with NO load in flight — the
+        // durable « displayed ≠ canonical » state the #907 gates forbid. Reload whenever the
+        // displayed page is not the canonical one (a missing Loaded — skeleton — reloads too).
+        val displayedPage = (current.mode as? TopicUiState.Mode.Loaded)?.topic?.page
+        val mustReload = hadResults || displayedPage != request.page
         _state.update {
             it.copy(search = it.search.copy(isActive = false, status = TopicSearchStatus.Idle))
         }
-        // loadCurrentPage already cancels searchJob + bumps the generation (takeOverFromSearch). When
-        // there is nothing to reload, drop the in-flight search ourselves so a late reply can't write.
-        if (hadResults) loadCurrentPage() else takeOverFromSearch()
+        // loadCurrentPage already cancels searchJob + bumps the generation (takeOverFromSearch).
+        // Reload on results (Done) OR on a displayed/canonical mismatch ; only the aligned
+        // no-result close skips it — then drop the in-flight search ourselves so a late reply
+        // can't write.
+        if (mustReload) loadCurrentPage() else takeOverFromSearch()
     }
 
     /**

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -2857,6 +2857,41 @@ class TopicViewModelTest {
     }
 
     @Test
+    fun `closing a failed search after a transition takeover reloads the canonical page (#913)`() = runTest {
+        // Verdict Sol (loupe/#910) : loupe tapped during the grace, search submitted during the
+        // transition (takeover kills the switch load), search FAILS, bar closed → the target must
+        // be reloaded ; the old « no results → no reload » path left the departed page displayed
+        // with the canonical page elsewhere and NO load in flight (the #907-forbidden state).
+        val form = TopicSearchForm(hashCheck = "tok", topicId = SAMPLE_POST, cat = SAMPLE_CAT, firstnum = 1)
+        val repository = FakeTopicRepository(
+            flowsToReturn = listOf(
+                flow { emit(fakeTopic(2, 5, title = "departed", searchForm = form)) },
+                flow { kotlinx.coroutines.awaitCancellation() },
+                flow { emit(fakeTopic(3, 5, title = "target")) },
+            ),
+        )
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            topicSearchRepository = FakeTopicSearchRepository(error = IllegalStateException("boom")),
+        )
+
+        viewModel.switchToPage(3)
+        // Mid-grace : departed page displayed (Loaded provisional), canonical = 3, loupe active.
+        viewModel.send(TopicIntent.OpenSearch)
+        viewModel.send(TopicIntent.SearchWordChanged("x"))
+        viewModel.send(TopicIntent.SubmitSearch)
+        assertEquals(TopicSearchStatus.Error, viewModel.state.value.search.status)
+
+        viewModel.send(TopicIntent.CloseSearch)
+
+        val landed = assertMode<TopicUiState.Mode.Loaded>(viewModel.state.value)
+        assertEquals("closing the failed search reloaded the CANONICAL page", "target", landed.topic.title)
+        assertEquals(3, viewModel.state.value.request.page)
+    }
+
+    @Test
     fun `pull-to-refresh is a no-op while the displayed page is not the canonical one (#910)`() = runTest {
         val repository = FakeTopicRepository(
             flowsToReturn = listOf(


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Fix immédiat prescrit par le verdict Codex « régression loupe » (instruit sur demande de @XaTriX) : `closeSearch()` recharge désormais dès que la page affichée ≠ canonique (ou pas de Loaded affiché), pas seulement sur résultats — l'échappatoire du mismatch durable « affichée ≠ canonique » est fermée.

Test ciblé : transition → grâce → recherche échouée → fermeture → la CIBLE est rechargée. Canonique verte (197 tests :feature:topic).

Closes #913.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqxgKdydUwQEqqJm6rkGUh