### PR TITLE
fix(topic): #813 — les images fantômes récupèrent au refresh explicite

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeCache.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeCache.kt
@@ -31,12 +31,28 @@ internal interface IntrinsicMediaSizeCache {
 
     fun putSuccess(url: String, size: IntSize)
 
+    /**
+     * Unconditional failure record — for RENDER-TIME writers only (the smiley error slot): their
+     * painter attempt is always current, a disposed painter never fires late. Async probes must
+     * use [putFailureIfEpoch] instead.
+     */
     fun putFailure(url: String, nowMillis: Long)
 
     /**
-     * #813 — drop every memoized failure (successes are kept: native sizes are immutable).
-     * Called on an explicit user refresh so a transient outage does not leave ghost images
-     * pinned to the cold fallback box until the TTL happens to be re-consulted.
+     * #813 — monotonic epoch bumped by [clearFailures]. An async probe captures it BEFORE probing
+     * and hands it back to [putFailureIfEpoch] : a probe that was already in flight when the user
+     * refreshed (its cancellation only lands at the next recomposition) can then no longer deposit
+     * a stale failure on top of the clear — the ghost would otherwise survive the refresh.
+     */
+    fun failureEpoch(): Int
+
+    /** Records the failure ONLY when no [clearFailures] happened since [epoch] was captured. */
+    fun putFailureIfEpoch(url: String, nowMillis: Long, epoch: Int)
+
+    /**
+     * #813 — drop every memoized failure (successes are kept: native sizes are immutable) and bump
+     * the failure epoch. Called on an explicit user refresh so a transient outage does not leave
+     * ghost images pinned to the cold fallback box until the TTL happens to be re-consulted.
      */
     fun clearFailures()
 }
@@ -62,6 +78,10 @@ internal class DefaultIntrinsicMediaSizeCache(
     private val insertionOrder = ArrayDeque<String>()
     private val lock = Any()
 
+    // #813 — bumped under [lock] by clearFailures; compared under the SAME lock in
+    // putFailureIfEpoch so "clear then stale write" can never interleave.
+    private var epoch = 0
+
     override fun get(url: String): IntSize? = (entries[url] as? Entry.Success)?.size
 
     override fun isFailureFresh(url: String, nowMillis: Long): Boolean {
@@ -73,8 +93,17 @@ internal class DefaultIntrinsicMediaSizeCache(
 
     override fun putFailure(url: String, nowMillis: Long) = put(url, Entry.Failure(nowMillis))
 
+    override fun failureEpoch(): Int = synchronized(lock) { epoch }
+
+    override fun putFailureIfEpoch(url: String, nowMillis: Long, epoch: Int) {
+        synchronized(lock) {
+            if (this.epoch == epoch) put(url, Entry.Failure(nowMillis))
+        }
+    }
+
     override fun clearFailures() {
         synchronized(lock) {
+            epoch++
             val failed = entries.filterValues { it is Entry.Failure }.keys
             failed.forEach { url ->
                 entries.remove(url)

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeCache.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeCache.kt
@@ -32,6 +32,13 @@ internal interface IntrinsicMediaSizeCache {
     fun putSuccess(url: String, size: IntSize)
 
     fun putFailure(url: String, nowMillis: Long)
+
+    /**
+     * #813 — drop every memoized failure (successes are kept: native sizes are immutable).
+     * Called on an explicit user refresh so a transient outage does not leave ghost images
+     * pinned to the cold fallback box until the TTL happens to be re-consulted.
+     */
+    fun clearFailures()
 }
 
 /**
@@ -66,6 +73,16 @@ internal class DefaultIntrinsicMediaSizeCache(
 
     override fun putFailure(url: String, nowMillis: Long) = put(url, Entry.Failure(nowMillis))
 
+    override fun clearFailures() {
+        synchronized(lock) {
+            val failed = entries.filterValues { it is Entry.Failure }.keys
+            failed.forEach { url ->
+                entries.remove(url)
+                insertionOrder.remove(url)
+            }
+        }
+    }
+
     private fun put(url: String, entry: Entry) {
         synchronized(lock) {
             if (!entries.containsKey(url)) insertionOrder.addLast(url)
@@ -97,4 +114,14 @@ internal object ProcessIntrinsicMediaSizeCache :
  */
 internal val LocalIntrinsicMediaSizeCache = staticCompositionLocalOf<IntrinsicMediaSizeCache> {
     ProcessIntrinsicMediaSizeCache
+}
+
+/**
+ * #813 — public seam for the hosting screens (:feature modules cannot see the internal cache):
+ * drop the memoized measurement failures so the next measure pass re-probes them. Call it on an
+ * explicit user refresh, BEFORE bumping the media-refresh generation passed to [PostRenderer] —
+ * clearing after the bump would let the relaunched effect re-read a still-fresh failure.
+ */
+fun clearPostMediaMeasurementFailures() {
+    ProcessIntrinsicMediaSizeCache.clearFailures()
 }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeMeasurer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeMeasurer.kt
@@ -8,6 +8,7 @@ import coil3.request.SuccessResult
 import coil3.size.Precision
 import coil3.size.Scale
 import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.CompletableDeferred
 
 /**
  * #175/#257 — probe a media's dimensions via a **bounded** Coil decode (aspect ratio + size class).
@@ -61,26 +62,43 @@ internal suspend fun measureIntrinsicMediaSize(
  *
  * The cache guard is a non-atomic check-then-act, so two callers racing on the SAME cold URL (the
  * BlockImage effect vs the paragraph effect, or two on-screen copies) could each start a probe before
- * the first result lands. [inFlightMeasurements] de-dupes that window: the first caller wins the URL and
- * the others no-op until it clears the entry (in a `finally`, so a cancelled probe also releases it).
- * Process-wide like [ProcessIntrinsicMediaSizeCache]; keyed by URL (native sizes are URL-immutable).
+ * the first result lands. [inFlightMeasurements] de-dupes that window: the first caller wins the URL,
+ * the others AWAIT its ticket then re-run the guard. The await (not a fire-and-forget no-op) matters
+ * for #813: when a refresh generation bump cancels the winning effect mid-probe, a plain "loser
+ * returns" would leave the URL cold with nobody left to probe it until the next refresh — the loser
+ * waking up on the ticket re-checks the cache and becomes the new winner. A CANCELLED winner records
+ * nothing (a cancelled probe is not a dead host), so its late unwind can never overwrite a fresh
+ * success either. Process-wide like [ProcessIntrinsicMediaSizeCache]; keyed by URL.
  */
-private val inFlightMeasurements: MutableSet<String> = ConcurrentHashMap.newKeySet()
+private val inFlightMeasurements = ConcurrentHashMap<String, CompletableDeferred<Unit>>()
 
 internal suspend fun measureAndCacheIntrinsicMediaSize(
     url: String,
     cache: IntrinsicMediaSizeCache,
     context: PlatformContext,
     imageLoader: ImageLoader,
+    // Injectable for the cancellation-race tests only — production callers keep the default.
+    probe: suspend (String, PlatformContext, ImageLoader) -> IntSize? = ::measureIntrinsicMediaSize,
 ) {
-    val now = System.currentTimeMillis()
-    if (cache.get(url) != null || cache.isFailureFresh(url, now)) return
-    // Lost the race to another in-flight probe for this URL — its putSuccess/putFailure will recompose us.
-    if (!inFlightMeasurements.add(url)) return
-    try {
-        val size = measureIntrinsicMediaSize(url, context, imageLoader)
-        if (size != null) cache.putSuccess(url, size) else cache.putFailure(url, now)
-    } finally {
-        inFlightMeasurements.remove(url)
+    while (true) {
+        val now = System.currentTimeMillis()
+        if (cache.get(url) != null || cache.isFailureFresh(url, now)) return
+        val ticket = CompletableDeferred<Unit>()
+        val winner = inFlightMeasurements.putIfAbsent(url, ticket)
+        if (winner != null) {
+            // Lost the race — wait for the in-flight probe to settle (result OR cancellation),
+            // then loop: a landed result short-circuits on the guard, a cancelled probe left the
+            // URL cold and this caller takes over.
+            winner.await()
+            continue
+        }
+        try {
+            val size = probe(url, context, imageLoader)
+            if (size != null) cache.putSuccess(url, size) else cache.putFailure(url, now)
+            return
+        } finally {
+            inFlightMeasurements.remove(url, ticket)
+            ticket.complete(Unit)
+        }
     }
 }

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeMeasurer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeMeasurer.kt
@@ -9,6 +9,8 @@ import coil3.size.Precision
 import coil3.size.Scale
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 
 /**
  * #175/#257 — probe a media's dimensions via a **bounded** Coil decode (aspect ratio + size class).
@@ -83,6 +85,11 @@ internal suspend fun measureAndCacheIntrinsicMediaSize(
     while (true) {
         val now = System.currentTimeMillis()
         if (cache.get(url) != null || cache.isFailureFresh(url, now)) return
+        // #813 — capture the failure epoch BEFORE probing: if the user refreshes (clearFailures)
+        // while this probe is in flight, its failure result is STALE — exactly the outage the user
+        // is retrying — and must not be re-deposited on top of the clear. Compose only cancels the
+        // old measure effect at the next recomposition, so this window is real, not theoretical.
+        val epoch = cache.failureEpoch()
         val ticket = CompletableDeferred<Unit>()
         val winner = inFlightMeasurements.putIfAbsent(url, ticket)
         if (winner != null) {
@@ -94,7 +101,11 @@ internal suspend fun measureAndCacheIntrinsicMediaSize(
         }
         try {
             val size = probe(url, context, imageLoader)
-            if (size != null) cache.putSuccess(url, size) else cache.putFailure(url, now)
+            // Belt for a probe that swallowed cancellation: never publish a result on behalf of a
+            // dead effect (the epoch guard below covers failures; a success is always welcome, but
+            // only from a live coroutine).
+            currentCoroutineContext().ensureActive()
+            if (size != null) cache.putSuccess(url, size) else cache.putFailureIfEpoch(url, now, epoch)
             return
         } finally {
             inFlightMeasurements.remove(url, ticket)

--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostRenderer.kt
@@ -30,7 +30,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -279,25 +281,44 @@ fun PostRenderer(
     // quote's header. Null (default) keeps the header inert — only the topic reading surface wires
     // it (the editor preview, MP threads and signatures have nowhere meaningful to navigate).
     onGoToCitedPost: ((page: Int, numreponse: Int) -> Unit)? = null,
+    // #813 — screen-owned retry generation for inline media. The hosting screen bumps it on an
+    // explicit user refresh (AFTER clearPostMediaMeasurementFailures()) so paragraphs re-probe
+    // failed measurements and inline painters restart — a ghost image (16 sp cold box / stuck
+    // error painter) becomes recoverable without leaving the screen. Default 0 = never bumped,
+    // the exact previous behaviour for surfaces without a refresh affordance (preview, MP,
+    // signatures). Explicit parameter at this entry point (it is screen state, not ambient
+    // context); distributed below via a private CompositionLocal like the file's other
+    // cross-cutting render context, so the recursive quote/spoiler chain stays untouched.
+    mediaRefreshGeneration: Int = 0,
 ) {
-    if (selectable) {
-        // #281 — allow selecting / copying a post's text. The SelectionContainer is wrapped at this
-        // ENTRY POINT only, never inside the recursive PostBlocksRenderer (Quote/Spoiler): a nested
-        // SelectionContainer silently breaks selection. Links (LinkAnnotation.Url) stay tappable
-        // inside a SelectionContainer; inline media carry a U+FFFC placeholder that can pollute a
-        // copied selection spanning them (known, acceptable limitation).
-        SelectionContainer(modifier = modifier) {
-            PostBlocksRenderer(blocks = content.blocks, quoteDepth = 0, onGoToCitedPost = onGoToCitedPost)
+    CompositionLocalProvider(LocalMediaRefreshGeneration provides mediaRefreshGeneration) {
+        if (selectable) {
+            // #281 — allow selecting / copying a post's text. The SelectionContainer is wrapped at this
+            // ENTRY POINT only, never inside the recursive PostBlocksRenderer (Quote/Spoiler): a nested
+            // SelectionContainer silently breaks selection. Links (LinkAnnotation.Url) stay tappable
+            // inside a SelectionContainer; inline media carry a U+FFFC placeholder that can pollute a
+            // copied selection spanning them (known, acceptable limitation).
+            SelectionContainer(modifier = modifier) {
+                PostBlocksRenderer(blocks = content.blocks, quoteDepth = 0, onGoToCitedPost = onGoToCitedPost)
+            }
+        } else {
+            PostBlocksRenderer(
+                blocks = content.blocks,
+                modifier = modifier,
+                quoteDepth = 0,
+                onGoToCitedPost = onGoToCitedPost,
+            )
         }
-    } else {
-        PostBlocksRenderer(
-            blocks = content.blocks,
-            modifier = modifier,
-            quoteDepth = 0,
-            onGoToCitedPost = onGoToCitedPost,
-        )
     }
 }
+
+/**
+ * #813 — internal distribution of [PostRenderer]'s `mediaRefreshGeneration` parameter to the
+ * paragraph measure effect and the inline image painters, across the recursive quote/spoiler
+ * renderers. `compositionLocalOf` (not static): the value changes at runtime on user refresh and
+ * only the readers (media paragraphs) must recompose.
+ */
+private val LocalMediaRefreshGeneration = compositionLocalOf { 0 }
 
 @Composable
 private fun PostBlocksRenderer(
@@ -388,8 +409,12 @@ private fun ParagraphBlock(inlines: List<PostInline>) {
     // Measure the not-yet-known URLs. Coil's execute() is a main-safe suspend call (it dispatches its
     // own I/O), and reuses the shared SingletonImageLoader caches the rendering AsyncImage hits — so no
     // double network fetch. A dead URL is recorded as a failure (TTL) so it is not re-fetched.
+    // #813 — the refresh generation keys the effect too: a re-parsed page yields a structurally
+    // EQUAL `inlines` (remember keeps the same set instance), so without it the effect never
+    // relaunched on pull-to-refresh and an expired failure TTL was never even re-consulted.
     val platformContext = LocalPlatformContext.current
-    LaunchedEffect(measurableUrls) {
+    val mediaRefreshGeneration = LocalMediaRefreshGeneration.current
+    LaunchedEffect(measurableUrls, mediaRefreshGeneration) {
         val loader = SingletonImageLoader.get(platformContext)
         measurableUrls.forEach { url ->
             measureAndCacheIntrinsicMediaSize(url, sizeCache, platformContext, loader)
@@ -1679,12 +1704,19 @@ internal fun imageInlineContent(image: PostInline.InlineImage, box: InlineMediaB
         } else {
             Modifier
         }
-        AsyncImage(
-            model = request,
-            contentDescription = image.description,
-            contentScale = PostMediaDisplayPolicy.inlineImageContentScale,
-            modifier = Modifier.fillMaxSize().then(longPressModifier),
-        )
+        // #813 — key() on the refresh generation recreates the AsyncImage node on an explicit user
+        // refresh: a painter stuck in error restarts its load (the remembered request may keep its
+        // instance — the painter, not the request, holds the error state). Deliberately key()
+        // rather than betting on ImageRequest equality semantics — Compose-native, deterministic.
+        // A healthy image reloads from Coil's memory cache, so a bump costs no visible flash.
+        key(LocalMediaRefreshGeneration.current) {
+            AsyncImage(
+                model = request,
+                contentDescription = image.description,
+                contentScale = PostMediaDisplayPolicy.inlineImageContentScale,
+                modifier = Modifier.fillMaxSize().then(longPressModifier),
+            )
+        }
     }
 }
 

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeCacheTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/IntrinsicMediaSizeCacheTest.kt
@@ -69,4 +69,35 @@ class IntrinsicMediaSizeCacheTest {
         assertEquals(IntSize(9, 9), cache.get("a"))
         assertEquals(IntSize(2, 2), cache.get("b"))
     }
+
+    @Test
+    fun `clearFailures drops failures but preserves successes (813 refresh contract)`() {
+        val cache = DefaultIntrinsicMediaSizeCache()
+        cache.putSuccess("ok", IntSize(70, 50))
+        cache.putFailure("ghost", nowMillis = 0L)
+        cache.clearFailures()
+        assertEquals(IntSize(70, 50), cache.get("ok"))
+        assertFalse("a cleared failure must not stay fresh", cache.isFailureFresh("ghost", nowMillis = 0L))
+    }
+
+    @Test
+    fun `clearFailures frees the failed url's insertion slot (no ghost eviction)`() {
+        val cache = DefaultIntrinsicMediaSizeCache(maxEntries = 2)
+        cache.putSuccess("a", IntSize(1, 1))
+        cache.putFailure("ghost", nowMillis = 0L)
+        cache.clearFailures()
+        // Would evict "a" if "ghost" still occupied a slot in the insertion order.
+        cache.putSuccess("b", IntSize(2, 2))
+        assertEquals(IntSize(1, 1), cache.get("a"))
+        assertEquals(IntSize(2, 2), cache.get("b"))
+    }
+
+    @Test
+    fun `a failure recorded after clearFailures is fresh again (TTL restarts on the new failure)`() {
+        val cache = DefaultIntrinsicMediaSizeCache(failureTtlMillis = 1_000L)
+        cache.putFailure("ghost", nowMillis = 0L)
+        cache.clearFailures()
+        cache.putFailure("ghost", nowMillis = 5_000L)
+        assertTrue(cache.isFailureFresh("ghost", nowMillis = 5_500L))
+    }
 }

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/MeasureAndCacheIntrinsicMediaSizeTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/MeasureAndCacheIntrinsicMediaSizeTest.kt
@@ -89,6 +89,38 @@ class MeasureAndCacheIntrinsicMediaSizeTest {
     }
 
     @Test
+    fun `a failure from a probe that predates clearFailures is discarded (813 stale write)`() = runTest {
+        val cache = DefaultIntrinsicMediaSizeCache()
+        val url = "https://hfr/ghost.jpg"
+        val loader = loaderReturning(url, ColorImage(width = 1, height = 1)) // bypassed by the fake probes
+        val probing = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+
+        // Old measure effect : its probe is in flight when the user refreshes. Compose only cancels
+        // it at the next recomposition — here it simply completes (with a failure) after the clear.
+        val old = launch {
+            measureAndCacheIntrinsicMediaSize(url, cache, context, loader) { _, _, _ ->
+                probing.complete(Unit)
+                release.await()
+                null
+            }
+        }
+        probing.await()
+
+        cache.clearFailures() // the user's explicit refresh, mid-probe
+        release.complete(Unit)
+        old.join()
+
+        assertFalse(
+            "a failure produced by a probe older than the clear must be discarded",
+            cache.isFailureFresh(url, System.currentTimeMillis()),
+        )
+        // The path stays open : the retry probes and lands.
+        measureAndCacheIntrinsicMediaSize(url, cache, context, loader) { _, _, _ -> IntSize(320, 240) }
+        assertEquals(IntSize(320, 240), cache.get(url))
+    }
+
+    @Test
     fun `a cancelled probe records nothing and a waiting caller takes over (813 race)`() = runTest {
         val cache = DefaultIntrinsicMediaSizeCache()
         val url = "https://hfr/slow.jpg"

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/MeasureAndCacheIntrinsicMediaSizeTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/MeasureAndCacheIntrinsicMediaSizeTest.kt
@@ -6,8 +6,13 @@ import androidx.test.core.app.ApplicationProvider
 import coil3.ColorImage
 import coil3.ImageLoader
 import coil3.test.FakeImageLoaderEngine
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -67,5 +72,57 @@ class MeasureAndCacheIntrinsicMediaSizeTest {
 
         assertNull("a fresh failure must short-circuit before probing", cache.get(url))
         assertTrue(cache.isFailureFresh(url, System.currentTimeMillis()))
+    }
+
+    @Test
+    fun `clearFailures re-opens the probe path (813 refresh contract)`() = runTest {
+        val cache = DefaultIntrinsicMediaSizeCache()
+        val url = "https://hfr/ghost.jpg"
+        cache.putFailure(url, System.currentTimeMillis())
+        // The outage recovered : the host now serves the image.
+        val loader = loaderReturning(url, ColorImage(width = 320, height = 240))
+
+        cache.clearFailures()
+        measureAndCacheIntrinsicMediaSize(url, cache, context, loader)
+
+        assertEquals(IntSize(320, 240), cache.get(url))
+    }
+
+    @Test
+    fun `a cancelled probe records nothing and a waiting caller takes over (813 race)`() = runTest {
+        val cache = DefaultIntrinsicMediaSizeCache()
+        val url = "https://hfr/slow.jpg"
+        val loader = loaderReturning(url, ColorImage(width = 1, height = 1)) // bypassed by the fake probes
+        val winnerProbing = CompletableDeferred<Unit>()
+
+        // Winner: takes the in-flight ticket then hangs until cancelled — the #813 generation bump
+        // cancelling the previous measure effect mid-probe.
+        val winner = launch {
+            measureAndCacheIntrinsicMediaSize(url, cache, context, loader) { _, _, _ ->
+                winnerProbing.complete(Unit)
+                awaitCancellation()
+            }
+        }
+        winnerProbing.await()
+
+        // Loser: arrives while the winner holds the ticket — must WAIT (not no-op), then take over.
+        val loser = launch {
+            measureAndCacheIntrinsicMediaSize(url, cache, context, loader) { _, _, _ ->
+                IntSize(320, 240)
+            }
+        }
+
+        winner.cancelAndJoin()
+        loser.join()
+
+        assertEquals(
+            "the waiting caller must re-probe after the cancelled winner released the ticket",
+            IntSize(320, 240),
+            cache.get(url),
+        )
+        assertFalse(
+            "a cancelled probe is not a dead host — no failure may be recorded",
+            cache.isFailureFresh(url, System.currentTimeMillis()),
+        )
     }
 }

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererGhostImageRecoveryTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererGhostImageRecoveryTest.kt
@@ -17,11 +17,14 @@ import androidx.test.core.app.ApplicationProvider
 import coil3.ColorImage
 import coil3.ImageLoader
 import coil3.SingletonImageLoader
+import coil3.intercept.Interceptor
+import coil3.request.ImageResult
 import coil3.test.FakeImageLoaderEngine
 import fr.forumhfr.redface2.core.model.PostBlock
 import fr.forumhfr.redface2.core.model.PostContent
 import fr.forumhfr.redface2.core.model.PostInline
 import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import java.util.concurrent.CopyOnWriteArrayList
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -36,10 +39,13 @@ import org.robolectric.annotation.GraphicsMode
  * then a `mediaRefreshGeneration` bump — WITHOUT disposing the composition (the historical
  * work-around was « citer puis revenir », which disposed the whole topic composition).
  *
- * The pin: the same live composition, fed a bumped generation, re-probes the URL and grows the
- * placeholder box from the 16 sp cold square to the measured size. Without the generation in the
- * measure effect's keys the effect never relaunched (structurally-equal `inlines` on refresh), and
- * the expired failure TTL was never even re-consulted — this test fails on the old code.
+ * Two pins, matching the two ghost mechanisms:
+ *  - the placeholder BOX grows from the 16 sp cold square to the measured size (the measure effect
+ *    relaunched — it never did on refresh before, `inlines` being structurally equal);
+ *  - the PAINTER actually re-attempts its load (what `key(generation)` buys) — proven by counting
+ *    the loader requests for the URL, pixel capture being unreliable for Coil drawings under this
+ *    harness. After the bump the URL must be requested at least twice more: the re-probe AND the
+ *    recreated painter. Without `key()` only the probe re-fires.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34], qualifiers = "w360dp-h780dp-xxhdpi")
@@ -54,6 +60,9 @@ class PostRendererGhostImageRecoveryTest {
 
     private val appContext: Context = ApplicationProvider.getApplicationContext()
 
+    /** Every url the loader was asked for, across engine swaps (class-level, cumulative). */
+    private val requestedUrls = CopyOnWriteArrayList<String>()
+
     @OptIn(coil3.annotation.DelicateCoilApi::class)
     private fun installLoader(serveGhost: Boolean) {
         val builder = FakeImageLoaderEngine.Builder()
@@ -61,10 +70,22 @@ class PostRendererGhostImageRecoveryTest {
             builder.intercept(ghostUrl, ColorImage(0xFF1565C0.toInt(), width = 320, height = 240))
         }
         // else: ghostUrl NOT intercepted → Coil error result = the production failure mode.
+        val engine = builder.build()
+        val counter = object : Interceptor {
+            override suspend fun intercept(chain: Interceptor.Chain): ImageResult {
+                (chain.request.data as? String)?.let(requestedUrls::add)
+                return chain.proceed()
+            }
+        }
         SingletonImageLoader.setUnsafe(
-            ImageLoader.Builder(appContext).components { add(builder.build()) }.build(),
+            ImageLoader.Builder(appContext).components {
+                add(counter)
+                add(engine)
+            }.build(),
         )
     }
+
+    private fun ghostRequestCount(): Int = requestedUrls.count { it == ghostUrl }
 
     @Test
     fun `explicit refresh (clear + generation bump) recovers a ghost inline image in place`() {
@@ -109,6 +130,8 @@ class PostRendererGhostImageRecoveryTest {
         // Phase 2 — the outage recovers, the user pulls to refresh: the screen clears the memoized
         // failures FIRST, then bumps the generation (the production order in TopicContent).
         installLoader(serveGhost = true)
+        composeTestRule.waitForIdle()
+        val requestsBeforeRefresh = ghostRequestCount()
         composeTestRule.runOnIdle {
             cache.clearFailures()
             generation++
@@ -127,5 +150,12 @@ class PostRendererGhostImageRecoveryTest {
             "the ghost box must grow to the measured size after the refresh (was $grownHeight)",
             grownHeight > 60.dp,
         )
+
+        // Painter proof (Sol gate r1) : the refresh must trigger BOTH the re-probe and a fresh
+        // painter load — ≥ 2 new loader requests for the URL. Without key(generation) the stuck
+        // error painter never re-requests and only the probe (+1) fires.
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            ghostRequestCount() >= requestsBeforeRefresh + 2
+        }
     }
 }

--- a/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererGhostImageRecoveryTest.kt
+++ b/core/ui/src/test/kotlin/fr/forumhfr/redface2/core/ui/post/PostRendererGhostImageRecoveryTest.kt
@@ -1,0 +1,131 @@
+package fr.forumhfr.redface2.core.ui.post
+
+import android.content.Context
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.getBoundsInRoot
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.height
+import androidx.test.core.app.ApplicationProvider
+import coil3.ColorImage
+import coil3.ImageLoader
+import coil3.SingletonImageLoader
+import coil3.test.FakeImageLoaderEngine
+import fr.forumhfr.redface2.core.model.PostBlock
+import fr.forumhfr.redface2.core.model.PostContent
+import fr.forumhfr.redface2.core.model.PostInline
+import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * #813 — a ghost inline image (its first measurement failed: dead host, transient outage) must
+ * become recoverable through the screen's EXPLICIT refresh path: `clearPostMediaMeasurementFailures()`
+ * then a `mediaRefreshGeneration` bump — WITHOUT disposing the composition (the historical
+ * work-around was « citer puis revenir », which disposed the whole topic composition).
+ *
+ * The pin: the same live composition, fed a bumped generation, re-probes the URL and grows the
+ * placeholder box from the 16 sp cold square to the measured size. Without the generation in the
+ * measure effect's keys the effect never relaunched (structurally-equal `inlines` on refresh), and
+ * the expired failure TTL was never even re-consulted — this test fails on the old code.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h780dp-xxhdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@OptIn(ExperimentalTestApi::class)
+class PostRendererGhostImageRecoveryTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val ghostUrl = "https://images.example.org/ghost-photo.jpg"
+
+    private val appContext: Context = ApplicationProvider.getApplicationContext()
+
+    @OptIn(coil3.annotation.DelicateCoilApi::class)
+    private fun installLoader(serveGhost: Boolean) {
+        val builder = FakeImageLoaderEngine.Builder()
+        if (serveGhost) {
+            builder.intercept(ghostUrl, ColorImage(0xFF1565C0.toInt(), width = 320, height = 240))
+        }
+        // else: ghostUrl NOT intercepted → Coil error result = the production failure mode.
+        SingletonImageLoader.setUnsafe(
+            ImageLoader.Builder(appContext).components { add(builder.build()) }.build(),
+        )
+    }
+
+    @Test
+    fun `explicit refresh (clear + generation bump) recovers a ghost inline image in place`() {
+        installLoader(serveGhost = false)
+        val cache = DefaultIntrinsicMediaSizeCache()
+        var generation by mutableIntStateOf(0)
+
+        composeTestRule.setContent {
+            RedfaceTheme(darkTheme = false, amoledTheme = false, dynamicColor = false) {
+                Surface(color = MaterialTheme.colorScheme.surface) {
+                    CompositionLocalProvider(LocalIntrinsicMediaSizeCache provides cache) {
+                        PostRenderer(
+                            content = PostContent(
+                                blocks = listOf(
+                                    PostBlock.Paragraph(
+                                        inlines = listOf(
+                                            // The text sibling keeps the image INLINE (no block
+                                            // promotion) — the ghost symptom is inline-specific.
+                                            PostInline.Text("regarde "),
+                                            PostInline.InlineImage(url = ghostUrl, description = "photo"),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            mediaRefreshGeneration = generation,
+                        )
+                    }
+                }
+            }
+        }
+
+        // Phase 1 — the probe fails and is memoized; the box stays the 16 sp cold square.
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            cache.isFailureFresh(ghostUrl, System.currentTimeMillis())
+        }
+        val coldHeight = composeTestRule.onNodeWithContentDescription("photo").getBoundsInRoot().height
+        assertTrue(
+            "cold ghost box must stay around the one-line square (was $coldHeight)",
+            coldHeight <= 24.dp,
+        )
+
+        // Phase 2 — the outage recovers, the user pulls to refresh: the screen clears the memoized
+        // failures FIRST, then bumps the generation (the production order in TopicContent).
+        installLoader(serveGhost = true)
+        composeTestRule.runOnIdle {
+            cache.clearFailures()
+            generation++
+        }
+        // Apply the recomposition so the keyed measure effect actually relaunches — under
+        // Robolectric, waitUntil's polling alone does not reliably drive that application.
+        composeTestRule.waitForIdle()
+
+        // Same composition (nothing was disposed) : the paragraph re-probes, the box grows.
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            cache.get(ghostUrl) != null
+        }
+        composeTestRule.runOnIdle {} // let the size write recompose the paragraph
+        val grownHeight = composeTestRule.onNodeWithContentDescription("photo").getBoundsInRoot().height
+        assertTrue(
+            "the ghost box must grow to the measured size after the refresh (was $grownHeight)",
+            grownHeight > 60.dp,
+        )
+    }
+}

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -63,6 +63,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -118,6 +119,7 @@ import fr.forumhfr.redface2.core.ui.post.PostImageActions
 import fr.forumhfr.redface2.core.ui.post.PostImageTarget
 import fr.forumhfr.redface2.core.ui.post.PostListScaffold
 import fr.forumhfr.redface2.core.ui.post.PostRenderer
+import fr.forumhfr.redface2.core.ui.post.clearPostMediaMeasurementFailures
 import fr.forumhfr.redface2.core.ui.theme.LocalBlockedQuoteAuthors
 import fr.forumhfr.redface2.core.ui.theme.LocalDisplayMetrics
 import fr.forumhfr.redface2.core.ui.theme.LocalIgnoreInlineColors
@@ -944,6 +946,17 @@ internal fun TopicContent(
     // the title falls back to the cached hint (or a generic label) and the counter to « Chargement… »
     // — never a page total that has not been parsed yet (#622).
     val loaded = state.mode as? TopicUiState.Mode.Loaded
+    // #813 — media-retry generation for the post renderers, bumped on each EXPLICIT user refresh
+    // (pull-to-refresh, double-tap) so ghost inline images re-probe (failed measure) and restart
+    // their painter. Failures are cleared BEFORE the bump (Sol framing) — the other order would let
+    // the relaunched measure effect re-read a still-fresh failure and skip the probe. Saveable so a
+    // config change mid-session keeps the count monotonic (a fresh composition retries on its own).
+    var mediaRefreshGeneration by rememberSaveable { mutableIntStateOf(0) }
+    val refreshWithMediaRetry = {
+        clearPostMediaMeasurementFailures()
+        mediaRefreshGeneration++
+        onIntent(TopicIntent.Refresh)
+    }
     // #411 — bottom action cluster hides on scroll-down, re-appears on scroll-up (RF1 parity).
     val bottomActionsVisible = rememberBottomActionsVisible(listState)
     val fallbackTitle = stringResource(R.string.topic_topbar_fallback_title)
@@ -1097,7 +1110,8 @@ internal fun TopicContent(
                     // preserved on refresh (the ViewModel emits no scroll effect).
                     PullToRefreshBox(
                         isRefreshing = state.isRefreshing,
-                        onRefresh = { onIntent(TopicIntent.Refresh) },
+                        // #813 — user refresh also clears + re-probes failed media measurements.
+                        onRefresh = refreshWithMediaRetry,
                         modifier = Modifier.fillMaxSize(),
                     ) {
                         // #300/#351 — the intra-page scrollbar now rides inside PostListScaffold
@@ -1151,7 +1165,7 @@ internal fun TopicContent(
                                 onOpenProfile = onOpenProfile,
                                 onSendPrivateMessage = onSendPrivateMessage,
                                 onDeleteRequest = onDeleteRequest,
-                                onDoubleTapRefresh = { onIntent(TopicIntent.Refresh) },
+                                onDoubleTapRefresh = refreshWithMediaRetry,
                                 onSearchNextResults = { onIntent(TopicIntent.SearchNextResultsPage) },
                                 listState = listState,
                                 multiQuoteSelection = multiQuoteNumreponses,
@@ -1161,6 +1175,8 @@ internal fun TopicContent(
                                 },
                                 pollManualExpanded = pollManualExpanded,
                                 onPollExpansionChanged = onPollExpansionChanged,
+                                // #813 — explicit-refresh retry for ghost inline images.
+                                mediaRefreshGeneration = mediaRefreshGeneration,
                             )
                         }
                     }
@@ -1638,6 +1654,8 @@ private fun TopicLoadedContent(
     // callback recording a tap on the poll card. Threaded down to the header card's poll.
     pollManualExpanded: Boolean? = null,
     onPollExpansionChanged: (Boolean) -> Unit = {},
+    /** #813 — screen-owned media-retry generation, threaded to each card's body renderer. */
+    mediaRefreshGeneration: Int = 0,
 ) {
     // Scroll-anchor (#104 follow-up): the post the reader was sent to (quote link, deep link, last-read).
     // Marked by tinting ONLY its identity band with tertiaryContainer (XaTriX: the left-rail attempt was
@@ -1914,6 +1932,8 @@ private fun TopicLoadedContent(
                         onToggleMultiQuote = multiQuoteToggle,
                         // #831 — long-press on a post image opens the image contextual menu.
                         onImageLongPress = postImageActions.onLongPress,
+                        // #813 — explicit-refresh retry for ghost inline images.
+                        mediaRefreshGeneration = mediaRefreshGeneration,
                     )
                 }
                 if (showLastReadMarker) {
@@ -2536,6 +2556,13 @@ internal fun TopicPostCard(
      * Null (previews/tests) leaves every image inert.
      */
     onImageLongPress: ((PostImageTarget) -> Unit)? = null,
+    /**
+     * #813 — screen-owned media-retry generation, forwarded to the BODY [PostRenderer] : bumped by
+     * the screen on an explicit user refresh so ghost inline images (failed measure/painter)
+     * re-probe without leaving the screen. The signature render keeps the default 0 (inert images,
+     * same stance as [onImageLongPress]). Default 0 for previews/tests.
+     */
+    mediaRefreshGeneration: Int = 0,
 ) {
     // #287 — structural spacing from the active density preset (Comfort = the historical rhythm).
     val m = LocalDisplayMetrics.current
@@ -2615,7 +2642,12 @@ internal fun TopicPostCard(
                     onImageLongPress?.let { PostImageActions(onLongPress = it) }
                 }
                 CompositionLocalProvider(LocalPostImageActions provides imageActions) {
-                    PostRenderer(content = post.content, selectable = true, onGoToCitedPost = onGoToCitedPost)
+                    PostRenderer(
+                        content = post.content,
+                        selectable = true,
+                        onGoToCitedPost = onGoToCitedPost,
+                        mediaRefreshGeneration = mediaRefreshGeneration,
+                    )
                 }
                 // #330 — the author signature (web parity), gated by the reading preference. Rendered
                 // with the shared PostRenderer (the signature is BBCode/HTML like the body) but in a


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Sous-item autonome de la passe images #876 (la spec sizing de #876 n'est pas touchée). Traite #813.

## Symptôme
Une image inline dont la première tentative échoue reste « fantôme » (box froide 16 sp quasi invisible) ; le pull-to-refresh est inefficace ; seul « citer puis revenir » (disposition complète de la composition) la réparait.

## Cause racine (deux mécanismes indépendants)
1. **Box figée** : l'échec de mesure est mémoïsé (TTL 60 s) mais l'effet de mesure `LaunchedEffect(measurableUrls)` ne se relance JAMAIS au refresh (le `PostContent` re-parsé est structurellement égal → même clé) — le TTL expiré n'est même pas re-consulté.
2. **Painter figé** : la request inline est `remember(url, context)` et l'`AsyncImage` n'a ni slot error ni clé de retry — un painter en échec le reste tant que la composition survit.

## Fix (cadrage Sol : (a)+(b), inline-only, pas de slot error cette nuit)
- `IntrinsicMediaSizeCache.clearFailures()` (les succès sont conservés — tailles natives immuables ; les slots d'insertion libérés) + seam public `clearPostMediaMeasurementFailures()` pour les écrans.
- `PostRenderer(mediaRefreshGeneration: Int = 0)` — paramètre explicite (état d'écran), distribué en interne par CompositionLocal privé (idiome du fichier, la récursion citations est couverte sans toucher 8 signatures). Il claque la clé de l'effet de mesure ET un `key()` autour de l'`AsyncImage` inline (restart déterministe du painter, sans parier sur l'equals d'ImageRequest).
- `TopicContent` : pull-to-refresh + double-tap font `clearFailures()` PUIS bump (ordre verrouillé au cadrage — l'inverse laisserait l'effet relancé re-lire un échec encore frais).
- **Course fermée** dans le measurer : le perdant du dédoublonnage in-flight ATTEND le ticket du gagnant puis re-vérifie — une probe annulée en plein vol (bump) ne peut ni laisser l'URL froide ni écrire un échec tardif ; une probe annulée n'écrit jamais putFailure (« annulé ≠ hôte mort »).

## Hors périmètre (assumé)
- Images **bloc** : slot error visible déjà en place — extension éventuelle dans une PR séparée.
- Slot error cliquable inline (host durablement mort sans pull) : évolution UX distincte, sortie du lot de nuit au cadrage.
- #831 (menu images liées-inline) : différé vers le viewer #182, décision commentée sur l'issue.

## Tests
- Cache : `clearFailures` préserve les succès, libère les slots (pas d'éviction fantôme), TTL repart sur un nouvel échec.
- Measurer : re-probe après clear ; **course annulation** — le perdant reprend la main, aucun échec enregistré par une probe annulée.
- Robolectric `PostRendererGhostImageRecoveryTest` : box 16 sp → taille mesurée après clear+bump **dans la même composition** (échoue sur l'ancien code).

## Validation
`detektAll :core:ui:testDebugUnitTest :feature:topic:testDebugUnitTest :core:ui:lintDebug :feature:topic:lintDebug --rerun-tasks` → **BUILD SUCCESSFUL** (Docker canonique).

Réf #813 (fermeture au dogfood émulateur après merge, avec la release groupée de nuit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YiNthxW8eDCwbXrWjLNPh