### PR TITLE
fix(topic): #868/#869/#870 — le panier multiquote survit jusqu'à l'envoi effectif

### DIFF
--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -1110,7 +1110,8 @@ fun RedfaceApp(intent: Intent?) {
         // the editor entry (read into the request, then cleared) so a later editor can never
         // resurrect a stale citation set. In-memory on purpose — the cards are transient by
         // decision (lot 2) : a process death keeps the #405 draft text but drops the cards.
-        var pendingEditorQuotes by remember { mutableStateOf<List<QuotedPostPreview>?>(null) }
+        // #868-#870 — carries `consumesBasket` too (cf. EditorQuotesHandoff).
+        var pendingEditorQuotes by remember { mutableStateOf<EditorQuotesHandoff?>(null) }
         // #465 — per-topic MANUAL poll-expansion choice, keyed by (cat, post) (one poll per topic),
         // twin of topicTitleCache / topicScrollAnchorCache: a page change replaces the TopicRoute
         // (new nav entry → new ViewModel), so a `rememberSaveable` toggle inside the poll card was
@@ -1776,13 +1777,30 @@ private data class TopicSubmitNavState(
  * [onEditorQuotesHandoff]) right before a PostEditorRoute is pushed with citations (« Citer N »
  * or a sheet escalation), read once by the editor entry into `PostEditorRequest.initialQuotes`,
  * then cleared (null). Never serialised into the route — the cards are transient by decision.
+ *
+ * #868/#869/#870 — the handoff also says whether the editor session CONSUMED the hoisted basket
+ * ([EditorQuotesHandoff.consumesBasket]): only a « Citer N » launch (or a sheet escalation of one)
+ * does. The basket is no longer cleared at editor OPEN — it survives a back/cancel so the
+ * selection re-arms the « Citer N » FAB — and is cleared on SUBMIT SUCCESS of a basket-consuming
+ * session only (a « Citer » simple / plain reply never empties a selection it never shipped).
  */
 private data class MultiQuoteNavState(
     val basket: MultiQuoteBasket?,
     val onToggle: (cat: Int, post: Int, preview: QuotedPostPreview) -> Unit,
     val onClear: () -> Unit,
-    val pendingEditorQuotes: List<QuotedPostPreview>? = null,
-    val onEditorQuotesHandoff: (List<QuotedPostPreview>?) -> Unit = {},
+    val pendingEditorQuotes: EditorQuotesHandoff? = null,
+    val onEditorQuotesHandoff: (EditorQuotesHandoff?) -> Unit = {},
+)
+
+/**
+ * #868-#870 — what a full-screen editor opening receives : the quote previews (cards), and whether
+ * a successful submit of THAT session must empty the hoisted multi-quote basket. `consumesBasket`
+ * is decided by the OPEN PATH (« Citer N » / escalation of a basket-armed sheet = true ; « Citer »
+ * simple, #823 long-press and plain replies = false) — never inferred from the quote count.
+ */
+internal data class EditorQuotesHandoff(
+    val quotes: List<QuotedPostPreview>,
+    val consumesBasket: Boolean,
 )
 
 /**
@@ -2488,7 +2506,12 @@ private fun RedfaceNavHost(
                     // (lot 3) — cards are independent of the text draft. The genuine sheet escalation
                     // uses onEscalateToFullEditor below.
                     onReply = { subcat, page, quotes ->
-                        multiQuoteNavState.onEditorQuotesHandoff(quotes.takeIf { it.isNotEmpty() })
+                        // #868-#870 — « Citer » simple / #823 long-press / plain reply : these
+                        // quotes never came from the basket, a submit must not empty it.
+                        multiQuoteNavState.onEditorQuotesHandoff(
+                            quotes.takeIf { it.isNotEmpty() }
+                                ?.let { EditorQuotesHandoff(it, consumesBasket = false) },
+                        )
                         backStack.add(
                             PostEditorRoute(
                                 mode = PostEditorMode.Reply,
@@ -2503,8 +2526,14 @@ private fun RedfaceNavHost(
                     // #843/#790 — the quick-reply sheet's ESCALATION only: the sheet just persisted
                     // the shared #405 row, so the editor auto-applies it (resumeSharedDraft = true,
                     // silent append — same composition act) WITHOUT surfacing the restore banner.
-                    onEscalateToFullEditor = { subcat, page, quotes ->
-                        multiQuoteNavState.onEditorQuotesHandoff(quotes.takeIf { it.isNotEmpty() })
+                    onEscalateToFullEditor = { subcat, page, quotes, consumesBasket ->
+                        // #868-#870 — the escalated editor inherits the sheet session's basket
+                        // consumption : a « Citer N » sheet escalated to full screen still empties
+                        // the basket on ITS successful submit, and only then.
+                        multiQuoteNavState.onEditorQuotesHandoff(
+                            quotes.takeIf { it.isNotEmpty() }
+                                ?.let { EditorQuotesHandoff(it, consumesBasket = consumesBasket) },
+                        )
                         backStack.add(
                             PostEditorRoute(
                                 mode = PostEditorMode.Reply,
@@ -2542,8 +2571,11 @@ private fun RedfaceNavHost(
                     onMultiQuote = { subcat, page ->
                         // #291 / #604 lot 3 — quote flavour of reply : the basket's previews are
                         // handed to the editor (cards, mockup P3) through the in-memory handoff.
-                        // The basket is cleared on launch: the selection's intent is consumed,
-                        // and backing out of the editor should not re-arm a stale « Citer N ».
+                        // #868/#869 — the basket is NO LONGER cleared on launch : backing out of
+                        // the editor keeps the selection armed (« Citer N » survives a cancel) ;
+                        // the clear moved to the SUBMIT SUCCESS of this basket-consuming session
+                        // (consumesBasket = true below). « Tout vider » (#436) stays the manual
+                        // reset.
                         // #843 — « Citer N » (3+) is a COLD full-editor open, not a sheet escalation:
                         // resumeSharedDraft = false, so an existing text draft is offered via the
                         // restore banner (cards are independent of it), instead of the silent append
@@ -2553,7 +2585,9 @@ private fun RedfaceNavHost(
                             ?.selections
                             .orEmpty()
                         if (selection.isNotEmpty()) {
-                            multiQuoteNavState.onEditorQuotesHandoff(selection)
+                            multiQuoteNavState.onEditorQuotesHandoff(
+                                EditorQuotesHandoff(selection, consumesBasket = true),
+                            )
                             backStack.add(
                                 PostEditorRoute(
                                     mode = PostEditorMode.Reply,
@@ -2564,7 +2598,6 @@ private fun RedfaceNavHost(
                                     resumeSharedDraft = false,
                                 ),
                             )
-                            multiQuoteNavState.onClear()
                         }
                     },
                     onEdit = { subcat, page, numreponse ->
@@ -2624,6 +2657,11 @@ private fun RedfaceNavHost(
                 // and the LaunchedEffect clears the slot so a LATER editor can never resurrect a
                 // stale citation set. Process death drops the handoff with the process : the
                 // restored editor keeps the #405 text, not the cards (transient by decision).
+                // #868-#870 — the handoff is CAPTURED here (remember runs before the clearing
+                // effect) : `consumesBasket` must still be known at submit time, long after the
+                // slot was nulled. An activity recreation loses the capture together with the
+                // hoisted basket itself (both plain remember) — consistent, nothing to clear.
+                val editorQuotesHandoff = remember { multiQuoteNavState.pendingEditorQuotes }
                 LaunchedEffect(Unit) { multiQuoteNavState.onEditorQuotesHandoff(null) }
                 PostEditorScreen(
                     request = PostEditorRequest(
@@ -2633,7 +2671,7 @@ private fun RedfaceNavHost(
                         numreponse = route.numreponse,
                         page = route.page,
                         subcat = route.subcat,
-                        initialQuotes = multiQuoteNavState.pendingEditorQuotes.orEmpty(),
+                        initialQuotes = editorQuotesHandoff?.quotes.orEmpty(),
                         resumeSharedDraft = route.resumeSharedDraft,
                     ),
                     // #604 lot 4a — the system back reaches here only AFTER the ViewModel
@@ -2658,6 +2696,12 @@ private fun RedfaceNavHost(
                         val below = backStack.getOrNull(backStack.lastIndex - 1)
                         if (topicId != null && isTopicEntryFor(below, route.cat, topicId)) {
                             topicSubmitNavState.onPublish(route.cat, topicId, targetPage, scrollTo)
+                        }
+                        // #868/#869 — the selection's intent is consumed by the SUCCESSFUL submit
+                        // of a basket-consuming session (« Citer N » / its escalation), and only
+                        // then : a failure, a back or a « Citer » simple never empty the basket.
+                        if (editorQuotesHandoff?.consumesBasket == true) {
+                            multiQuoteNavState.onClear()
                         }
                         // Same guarded pop as the global `onBack` lambda: never collapse below the
                         // tab root.

--- a/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
+++ b/app/src/main/kotlin/fr/forumhfr/redface2/navigation/RedfaceNavigation.kt
@@ -2529,10 +2529,12 @@ private fun RedfaceNavHost(
                     onEscalateToFullEditor = { subcat, page, quotes, consumesBasket ->
                         // #868-#870 — the escalated editor inherits the sheet session's basket
                         // consumption : a « Citer N » sheet escalated to full screen still empties
-                        // the basket on ITS successful submit, and only then.
+                        // the basket on ITS successful submit, and only then. The handoff is built
+                        // UNCONDITIONALLY (gate Sol r1) : a « Citer N » sheet whose cards were all
+                        // removed before escalating still consumes the basket — the flag follows
+                        // the OPEN PATH, never the quote count.
                         multiQuoteNavState.onEditorQuotesHandoff(
-                            quotes.takeIf { it.isNotEmpty() }
-                                ?.let { EditorQuotesHandoff(it, consumesBasket = consumesBasket) },
+                            EditorQuotesHandoff(quotes, consumesBasket = consumesBasket),
                         )
                         backStack.add(
                             PostEditorRoute(
@@ -2659,9 +2661,11 @@ private fun RedfaceNavHost(
                 // restored editor keeps the #405 text, not the cards (transient by decision).
                 // #868-#870 — the handoff is CAPTURED here (remember runs before the clearing
                 // effect) : `consumesBasket` must still be known at submit time, long after the
-                // slot was nulled. An activity recreation loses the capture together with the
-                // hoisted basket itself (both plain remember) — consistent, nothing to clear.
-                val editorQuotesHandoff = remember { multiQuoteNavState.pendingEditorQuotes }
+                // slot was nulled. Keyed on the route (gate Sol r1) so two editor routes
+                // succeeding each other at the same Compose position can never share a capture.
+                // An activity recreation loses the capture together with the hoisted basket
+                // itself (both plain remember) — consistent, nothing to clear.
+                val editorQuotesHandoff = remember(route) { multiQuoteNavState.pendingEditorQuotes }
                 LaunchedEffect(Unit) { multiQuoteNavState.onEditorQuotesHandoff(null) }
                 PostEditorScreen(
                     request = PostEditorRequest(
@@ -2700,7 +2704,13 @@ private fun RedfaceNavHost(
                         // #868/#869 — the selection's intent is consumed by the SUCCESSFUL submit
                         // of a basket-consuming session (« Citer N » / its escalation), and only
                         // then : a failure, a back or a « Citer » simple never empty the basket.
-                        if (editorQuotesHandoff?.consumesBasket == true) {
+                        // Guarded on the basket still being THIS topic's (gate Sol r1) : the one
+                        // basket is keyed (cat, post), so if it was re-armed on another topic
+                        // while this editor lived, the submit must not wipe that newer selection.
+                        if (editorQuotesHandoff?.consumesBasket == true &&
+                            topicId != null &&
+                            multiQuoteNavState.basket?.matches(route.cat, topicId) == true
+                        ) {
                             multiQuoteNavState.onClear()
                         }
                         // Same guarded pop as the global `onBack` lambda: never collapse below the

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModel.kt
@@ -189,17 +189,22 @@ class QuickReplyViewModel @AssistedInject constructor(
             _state.update {
                 it.copy(text = TextFieldValue(text = body, selection = TextRange(body.length)))
             }
-            if (initialQuotes.isEmpty() && _state.value.quotes.isEmpty()) return@launch
+            // #870 — the delivered set IS the citation session : quotes armed under a PREVIOUS
+            // sheet session never resurrect on a new opening (they used to merge idempotently,
+            // desynchronising the sheet from the « Citer N » FAB). Nothing the user selected is
+            // lost anymore : since #868/#869 the hoisted basket survives until an actual send, so
+            // a re-open via « Citer N » re-delivers the full selection — which supersedes the old
+            // fold-into-inline behaviour the cards-OFF branch had for the same no-drop reason.
+            if (initialQuotes.isEmpty()) {
+                if (_state.value.quotes.isNotEmpty()) _state.update { it.copy(quotes = emptyList()) }
+                return@launch
+            }
+            _state.update { it.copy(quotes = emptyList()) }
             if (userPreferencesRepository.observeQuoteCardsEnabled().first()) {
+                // Through onQuoteAdded : keeps the dedup + #808 cap semantics of a manual add.
                 initialQuotes.forEach(::onQuoteAdded)
             } else {
-                // Gate Codex (finding 1) — cards armed under a previous cards-ON session must not
-                // survive an OFF opening : rendered again, they would re-arm the cards submit
-                // path against the arbitrage. They are FOLDED into this opening's inline insert
-                // instead (nothing the user cited is dropped), deduplicated like cards were.
-                val pending = (_state.value.quotes + initialQuotes).distinctBy { it.numreponse }
-                _state.update { it.copy(quotes = emptyList()) }
-                materializeInlineQuotes(pending)
+                materializeInlineQuotes(initialQuotes.distinctBy { it.numreponse })
             }
         }
     }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModel.kt
@@ -142,6 +142,10 @@ class QuickReplyViewModel @AssistedInject constructor(
      */
     private var materializeJob: Job? = null
 
+    // #868-#870 (gate Sol) — one opening at a time : a re-open cancels the previous opening's
+    // seed/arm work so two rapid openings can never finish out of order (last opening wins).
+    private var openJob: Job? = null
+
     /** #405 — the SAME key the full-screen reply editor uses for this topic. */
     private val draftKey: String = EditorDraftKey.reply(request.cat, request.topicId)
 
@@ -183,7 +187,8 @@ class QuickReplyViewModel @AssistedInject constructor(
      */
     fun onSheetOpened(initialQuotes: List<QuotedPostPreview> = emptyList()) {
         materializeJob?.cancel()
-        viewModelScope.launch {
+        openJob?.cancel()
+        openJob = viewModelScope.launch {
             initJob.join()
             val body = draftStore.load(draftOwner, draftKey)?.body.orEmpty()
             _state.update {

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -159,9 +159,15 @@ fun TopicScreen(
      * (#790): the sheet JUST wrote the #405 row, so the editor auto-applies it (appending to any
      * typed text) WITHOUT a banner — re-proposing a draft the user is visibly continuing would be
      * noise. Defaults to a no-op for non-topic callers (previews/tests never escalate).
+     * #868-#870 — `consumesBasket` forwards the sheet session's basket consumption : true only when
+     * the escalated sheet was opened by « Citer N » (its successful submit then empties the basket).
      */
-    onEscalateToFullEditor: (subcat: Int, page: Int, quotes: List<QuotedPostPreview>) -> Unit =
-        { _, _, _ -> },
+    onEscalateToFullEditor: (
+        subcat: Int,
+        page: Int,
+        quotes: List<QuotedPostPreview>,
+        consumesBasket: Boolean,
+    ) -> Unit = { _, _, _, _ -> },
     /**
      * Open the editor in edit mode (Phase 2D, #147). HFR exposes the edit link on
      * the post's left toolbar only when the post belongs to the current user and
@@ -912,8 +918,13 @@ internal fun TopicContent(
     onReply: (subcat: Int, page: Int, quotes: List<QuotedPostPreview>) -> Unit,
     // #843 — the quick-reply sheet's escalation (resumeSharedDraft = true, silent append) ; distinct
     // from [onReply] which is a COLD full-editor open (resumeSharedDraft = false → restore banner).
-    onEscalateToFullEditor: (subcat: Int, page: Int, quotes: List<QuotedPostPreview>) -> Unit =
-        { _, _, _ -> },
+    // #868-#870 — carries the session's basket consumption (cf. TopicScreen KDoc).
+    onEscalateToFullEditor: (
+        subcat: Int,
+        page: Int,
+        quotes: List<QuotedPostPreview>,
+        consumesBasket: Boolean,
+    ) -> Unit = { _, _, _, _ -> },
     onEdit: (subcat: Int, page: Int, numreponse: Int) -> Unit,
     onEditFirstPost: (subcat: Int, page: Int, numreponse: Int) -> Unit,
     onOpenPage: (Int) -> Unit,
@@ -1047,6 +1058,10 @@ internal fun TopicContent(
                     when (writingSurfaceFor(state.writingSurfacePreset, quoteCount = selection.size)) {
                         WritingSurface.FULL_EDITOR -> onMultiQuote(subcat, page)
                         WritingSurface.SHEET -> {
+                            // #868/#869 — the basket is NO LONGER cleared here : closing the sheet
+                            // without sending keeps the selection armed (the « Citer N » FAB and
+                            // counter survive a cancel). The clear happens on the sheet's
+                            // SubmitSucceeded (or its escalation's) via consumesBasket below.
                             quickReplyFor = QuickReplyLaunch(
                                 request = QuickReplyRequest(
                                     cat = state.request.cat,
@@ -1055,8 +1070,8 @@ internal fun TopicContent(
                                     page = page,
                                 ),
                                 initialQuotes = selection,
+                                consumesBasket = true,
                             )
-                            onClearMultiQuote()
                         }
                     }
                 },
@@ -1192,10 +1207,21 @@ internal fun TopicContent(
             onEscalate = { quotes ->
                 quickReplyFor = null
                 // #843 — genuine escalation: resumeSharedDraft = true (silent append), NOT the cold
-                // onReply path which surfaces the restore banner.
-                onEscalateToFullEditor(launch.request.subcat, launch.request.page, quotes)
+                // onReply path which surfaces the restore banner. #868-#870 — the escalated editor
+                // inherits this session's basket consumption.
+                onEscalateToFullEditor(
+                    launch.request.subcat,
+                    launch.request.page,
+                    quotes,
+                    launch.consumesBasket,
+                )
             },
             onSubmitted = { targetPage, scrollTo ->
+                // #868/#869 — a SUCCESSFUL send of a basket-consuming session (« Citer N » ≤ 2)
+                // finally consumes the selection ; a dismiss/cancel above never does.
+                if (launch.consumesBasket) {
+                    onClearMultiQuote()
+                }
                 quickReplyFor = null
                 onQuickReplySubmitted(targetPage, scrollTo)
             },
@@ -3439,6 +3465,13 @@ private fun ReplyFab(onClick: () -> Unit) {
 internal data class QuickReplyLaunch(
     val request: QuickReplyRequest,
     val initialQuotes: List<QuotedPostPreview> = emptyList(),
+    /**
+     * #868-#870 — true only when this opening consumed the hoisted multi-quote basket
+     * (« Citer N » under the sheet threshold) : a successful submit of THIS session (or of its
+     * full-screen escalation) then empties the basket. « Citer » simple and the reply FAB leave
+     * the basket alone — they never shipped it.
+     */
+    val consumesBasket: Boolean = false,
 )
 
 /** #806 — the two composition surfaces a write tap can open. */

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/QuickReplyViewModelTest.kt
@@ -316,14 +316,30 @@ class QuickReplyViewModelTest {
     }
 
     @Test
-    fun `onSheetOpened appends idempotently after the cards the VM already holds`() = runTest {
+    fun `reopening resets the cards to exactly the delivered set (870)`() = runTest {
+        // #870 — the VM outlives the sheet : cards from a PREVIOUS session must not merge into a
+        // new opening (they desynchronised the sheet from the « Citer N » FAB). The selection is
+        // safe in the hoisted basket (#868/#869 : it now survives until an actual send).
         val viewModel = quickReplyViewModel()
         viewModel.onQuoteAdded(preview(303, "carol"))
-        // Re-opening with an overlap (303) must neither duplicate nor reorder the existing card.
-        viewModel.onSheetOpened(listOf(preview(101, "alice"), preview(303, "carol")))
+        viewModel.onSheetOpened(listOf(preview(101, "alice"), preview(202, "bob")))
         advanceUntilIdle()
 
-        assertEquals(listOf(303, 101), viewModel.state.value.quotes.map { it.numreponse })
+        assertEquals(listOf(101, 202), viewModel.state.value.quotes.map { it.numreponse })
+    }
+
+    @Test
+    fun `reopening with no quotes drops the stale cards and keeps the draft text (870)`() = runTest {
+        val draftStore = FakeQuickReplyDraftStore(initialBody = "brouillon")
+        val viewModel = quickReplyViewModel(draftStore = draftStore)
+        viewModel.onQuoteAdded(preview(303, "carol"))
+        // A plain « Répondre » reopening delivers nothing : the previous session's cards must not
+        // resurrect, while the #405 draft text is untouched (its row stays the source of truth).
+        viewModel.onSheetOpened()
+        advanceUntilIdle()
+
+        assertTrue("stale cards must not survive a fresh opening", viewModel.state.value.quotes.isEmpty())
+        assertEquals("brouillon", viewModel.state.value.text.text)
     }
 
     // ----- #805 : cartes OFF (défaut production) — [quotemsg] inline dans le champ ----------
@@ -445,9 +461,11 @@ class QuickReplyViewModelTest {
     }
 
     @Test
-    fun `stale cards from a previous ON session are folded into the inline insert`() = runTest {
-        // Gate Codex (finding 1) — the VM outlives the sheet : cards armed while the preference
-        // was ON must not re-render (nor re-arm the cards submit path) after a flip to OFF.
+    fun `stale cards from a previous ON session are dropped by an OFF opening (870)`() = runTest {
+        // #870 supersedes the gate-Codex fold (finding 1 of #805) : stale cards are DROPPED, not
+        // folded — the delivered set is the session, and the citation selection now survives in
+        // the hoisted basket (#868/#869), so nothing the user selected is lost. The OFF opening
+        // still never re-arms the cards submit path.
         val repository = FakeQuickReplyRepository()
         val viewModel = quickReplyViewModel(replyRepository = repository, quoteCardsEnabled = false)
         viewModel.onQuoteAdded(preview(101, "alice"))
@@ -458,7 +476,7 @@ class QuickReplyViewModelTest {
         val state = viewModel.state.value
         assertTrue("no card survives an OFF opening", state.quotes.isEmpty())
         assertEquals(
-            "[quotemsg=101]corps[/quotemsg]\n\n[quotemsg=202]corps[/quotemsg]\n",
+            "[quotemsg=202]corps[/quotemsg]\n",
             state.text.text,
         )
     }


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Trio de bugs multiquote instruit ENSEMBLE (retours testeurs 0.26.2+). Traite #868, #869, #870.

## Causes racines (recon vérifiée file:line)
- **#868/#869** : le panier hoisté (`multiQuoteBasket`, RedfaceApp) était **vidé à l'OUVERTURE du composeur** dans les deux chemins (« Citer N » plein écran ET pré-armement sheet ≤ 2), sans aucune restauration au retour sans envoi → FAB « ❝N » disparu, compteur reparti à 1.
- **#870** : le `QuickReplyViewModel` (scopé à l'entrée nav topic, il survit à la fermeture de la sheet) gardait SES quotes et **fusionnait** chaque nouvelle livraison dedans → sheet et FAB désynchronisés. Le passage single-VM #895 allongeait encore la survie de ce second store.

## Fix (cadrage Sol GO, sémantique verrouillée)
1. **Le panier persiste jusqu'au SUBMIT RÉUSSI d'une session qui l'a consommé.** `EditorQuotesHandoff` / `QuickReplyLaunch` portent un flag explicite `consumesBasket` — décidé par le CHEMIN d'ouverture (« Citer N » et son escalade = true ; « Citer » simple, appui long #823, réponse simple = false — jamais déduit du nombre de citations). Échec d'envoi, dismiss, back, édition de post : ne vident jamais. « Tout vider » (#436) reste le reset manuel. Garde `isTopicEntryFor` inchangée.
2. **`onSheetOpened` remet les cartes au set livré** (plus de merge). Les cartes d'une session précédente ne ressuscitent plus — ni en cartes (ON) ni pliées dans l'insert inline (OFF : le fold no-drop de #805 est supersédé, la sélection vit désormais dans le panier lui-même).
3. L'entrée éditeur **capture le handoff par `remember`** avant l'effet qui vide le slot — `consumesBasket` est encore connu au moment du submit.

## Sémantique assumée
Le commentaire historique « backing out should not re-arm a stale Citer N » est inversé : c'est précisément ce que les 3 issues réclament (le testeur revient, sa sélection est toujours là). « Citer » simple reste une intention distincte du panier (contrat explicite, décision produit non anticipée — cadrage Sol point 4).

## Tests
- VM : réouverture = exactement le set livré (#870) ; réouverture à vide = cartes périmées jetées, texte du brouillon intact ; OFF : cartes périmées JETÉES (remplace le test du fold #805, rationale dans le test).
- Les contrats du cycle de vie du panier côté :app (état compose hoisté) sont épinglés par le **dogfood émulateur/device requis avant release** (exigence du cadrage — pas de substitution de gate) : back conserve N, +1 donne N+1, envoi « Citer N » vide, envoi simple ne vide pas, isolation entre topics.

## Validation
`detektAll :feature:topic:testDebugUnitTest :app:compileProdDebugKotlin` → **BUILD SUCCESSFUL** (Docker canonique).

Réf #868 #869 #870 (fermeture après dogfood + release groupée).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YiNthxW8eDCwbXrWjLNPh