### PR TITLE
chore(release): 0.29.0 — lot de nuit 12→13/07

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,23 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.29.0` — `internal` (dev) — 2026-07-13
+
+**Lot de nuit 12→13/07** (#813 images fantômes, #862 épinglés drapeaux, trio éditeur #873/#900/#872, garde citation #583, fix loupe #913 de la veille). Chantiers cadrés + gatés hors-bande (GPT-5.6 Sol) ; vérification visuelle émulateur non réalisée cette nuit (hôte KVM HS — reboot machine requis), couverture par tests JVM/Robolectric + fixtures serveur réelles.
+
+### Vue topic
+- **#813 — les images fantômes se récupèrent** : une image inline dont le premier chargement a échoué (hébergeur en panne, coupure) restait un carré quasi invisible jusqu'à « citer puis revenir ». Le tirer-pour-rafraîchir (et le double-tap) relance désormais mesure ET chargement. (PR #919)
+- **#913 — la loupe de recherche reste cohérente** après la fermeture d'une recherche pendant une transition de page (reliquat de la veille). (PR #914)
+
+### Drapeaux
+- **#862 — les sujets épinglés flaggés apparaissent dans les listes** (favoris/cyan/rouges) : le serveur les omet de ses buckets dans TOUTES les catégories (prouvé par captures) ; le supplément `topics/last` couvre maintenant les 19 catégories, en UN balayage partagé par les trois types (barrière de génération au refresh — cadrage Sol 5 rounds). (PR #922)
+
+### Éditeur
+- **#873 — l'aperçu affiche les smileys standards** (`:jap:`, `:lol:`, `:pt1cable:`… — 51 tokens), validés contre la table canonique (pas de faux positifs type `10:30:45`). Les persos `[:name]` restent en texte (résolution d'URL = suivi) ; les émoticônes ponctuation (`:)`, `:D`) volontairement non converties en aperçu. (PR #921)
+- **#900 — panneau smileys wiki compacté** : ligne de titre retirée (les onglets nomment la surface, TalkBack garde une annonce paneTitle) — une rangée de plus visible. (PR #921)
+- **#872 — le libellé « Contenu BBCode » ne se rogne plus** aux grandes tailles de police (réservation du label indexée sur l'échelle de police). (PR #921)
+- **#583 — une citation qui ne se matérialise pas bloque l'envoi** (erreur retryable) au lieu de poster silencieusement SANS le bloc cité. (PR #922)
+
 ## `0.28.1` — `internal` (dev) — 2026-07-13
 
 **Stale-while-switching** (#910, PR #911 — retour immédiat de XaTriX sur la 0.28.0 : « ça saute/flash toujours sur une page non connue »).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.28.1"
+        versionName = "0.29.0"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,3 +1,7 @@
-Redface 2 v0.28.1 — dev.
+Redface 2 v0.29.0 — dev.
 
-- No more skeleton flash on fast page changes: the previous page stays on screen while the new one loads (the skeleton only appears past 250 ms).
+- Ghost images now recover on pull-to-refresh.
+- Pinned topics finally show up in the flag lists.
+- The editor preview renders standard smileys.
+- A failed quote prefill blocks the send instead of silently posting without it.
+- Misc: denser smiley panel, editor label, search icon consistency.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,3 +1,7 @@
-Redface 2 v0.28.1 — dev.
+Redface 2 v0.29.0 — dev.
 
-- Plus de squelette flashé sur un changement de page rapide : l'ancienne page reste affichée pendant que la nouvelle charge (le squelette n'apparaît qu'au-delà de 250 ms).
+- Les images qui ne s'affichaient jamais se récupèrent d'un tirer-pour-rafraîchir.
+- Les sujets épinglés apparaissent enfin dans les listes de drapeaux.
+- L'aperçu de l'éditeur affiche les smileys standards.
+- Une citation qui échoue bloque l'envoi au lieu de poster sans le bloc cité.
+- Divers : panneau smileys plus dense, libellé éditeur, loupe de recherche.


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Bump versionName + CHANGELOG + whatsnew pour la release groupée de nuit : #813 (PR #919) · #862+#583 (PR #922) · #873/#900/#872 (PR #921) · #913 (PR #914, reliquat de la veille non releasé).

Politique A : nouveaux chantiers → mineur. Dispatch `channel=dev --ref dev` après merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YiNthxW8eDCwbXrWjLNPh