### PR TITLE
chore(release): 0.29.1 — trio multiquote

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,15 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.29.1` — `internal` (dev) — 2026-07-13
+
+**Trio multiquote** (#868/#869/#870, PR #920 — le lot retenu de la nuit, mergé après dogfood émulateur complet des 8 contrats du cadrage, au matin post-reboot).
+
+### Vue topic / composer
+- **#868 — le FAB « Citer N » survit** à l'ouverture de l'éditeur + retour sans envoi : le panier n'est plus vidé à l'OUVERTURE mais à l'**envoi réussi** d'une session qui l'a consommé (flag explicite porté par le chemin d'ouverture — « Citer » simple, réponse, édition et échecs d'envoi ne le vident jamais ; « Tout vider » reste le reset manuel).
+- **#869 — le compteur repart de N**, plus jamais de reset à 1 après un aller-retour.
+- **#870 — plus de citations fantômes** : la feuille de réponse remet ses citations exactement au set livré à chaque ouverture (plus de fusion avec une session précédente).
+
 ## `0.29.0` — `internal` (dev) — 2026-07-13
 
 **Lot de nuit 12→13/07** (#813 images fantômes, #862 épinglés drapeaux, trio éditeur #873/#900/#872, garde citation #583, fix loupe #913 de la veille). Chantiers cadrés + gatés hors-bande (GPT-5.6 Sol) ; vérification visuelle émulateur non réalisée cette nuit (hôte KVM HS — reboot machine requis), couverture par tests JVM/Robolectric + fixtures serveur réelles.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.29.0"
+        versionName = "0.29.1"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,7 +1,3 @@
-Redface 2 v0.29.0 — dev.
+Redface 2 v0.29.1 — dev.
 
-- Ghost images now recover on pull-to-refresh.
-- Pinned topics finally show up in the flag lists.
-- The editor preview renders standard smileys.
-- A failed quote prefill blocks the send instead of silently posting without it.
-- Misc: denser smiley panel, editor label, search icon consistency.
+- Multiquote fixed: the "Quote N" basket survives editor round-trips (no more vanishing FAB or counter reset), and the reply sheet no longer shows ghost quotes from a previous session. The basket only clears on a successful send.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,7 +1,3 @@
-Redface 2 v0.29.0 — dev.
+Redface 2 v0.29.1 — dev.
 
-- Les images qui ne s'affichaient jamais se récupèrent d'un tirer-pour-rafraîchir.
-- Les sujets épinglés apparaissent enfin dans les listes de drapeaux.
-- L'aperçu de l'éditeur affiche les smileys standards.
-- Une citation qui échoue bloque l'envoi au lieu de poster sans le bloc cité.
-- Divers : panneau smileys plus dense, libellé éditeur, loupe de recherche.
+- Multiquote réparé : le panier « Citer N » survit aux allers-retours avec l'éditeur (plus de FAB disparu ni de compteur reparti à 1), et la feuille de réponse n'affiche plus de citations fantômes d'une session précédente. Le panier ne se vide qu'à l'envoi réussi.


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Bump + changelog + whatsnew pour livrer le trio multiquote #868/#869/#870 (PR #920, mergée après dogfood émulateur complet — 8 contrats validés, compte-rendu sur la PR). Patch de 0.29.0 (politique A : même cycle de chantiers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YiNthxW8eDCwbXrWjLNPh