### PR TITLE
fix(search): onglets catégories conservés après bascule de catégorie (#918)

### DIFF
--- a/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchViewModel.kt
+++ b/feature/search/src/main/kotlin/fr/forumhfr/redface2/feature/search/SearchViewModel.kt
@@ -305,11 +305,23 @@ class SearchViewModel @AssistedInject constructor(
             outcome.fold(
                 onSuccess = { page ->
                     _state.update {
+                        // #918 — HFR omits the pivot from explicit-category responses. Keep the
+                        // categories discovered by the originating all-category search so
+                        // the user can continue switching tabs. A fresh all-category search
+                        // still replaces the pivot, including with an empty result.
+                        val pivotCategories = page.pivotCategories.ifEmpty {
+                            if (scope is SearchCategoryScope.Category) it.pivotCategories else emptyList()
+                        }
+                        val selectedCategory = when (scope) {
+                            is SearchCategoryScope.Category ->
+                                pivotCategories.firstOrNull { category -> category.id == scope.id }
+                            SearchCategoryScope.All -> page.selectedCategory
+                        }
                         it.copy(
                             isLoading = false,
                             results = page.topics,
-                            pivotCategories = page.pivotCategories,
-                            selectedCategory = page.selectedCategory,
+                            pivotCategories = pivotCategories,
+                            selectedCategory = selectedCategory,
                             errorMessage = null,
                         )
                     }

--- a/feature/search/src/test/kotlin/fr/forumhfr/redface2/feature/search/SearchViewModelTest.kt
+++ b/feature/search/src/test/kotlin/fr/forumhfr/redface2/feature/search/SearchViewModelTest.kt
@@ -213,27 +213,27 @@ class SearchViewModelTest {
 
     @Test
     fun `CategorySelected re-runs the search scoped to the picked category`() = runTest {
+        val initialPivot = listOf(
+            SearchPivotCategory(id = 1, label = "Hardware", isSelected = true),
+            SearchPivotCategory(id = 10, label = "Programmation", isSelected = false),
+        )
         coEvery { repo.search(SearchRequest(query = "android", category = SearchCategoryScope.All)) } returns
             fakePage(
                 topics = listOf(fakeTopic(1, "global hit", cat = 1)),
-                pivot = listOf(
-                    SearchPivotCategory(id = 1, label = "Hardware", isSelected = true),
-                    SearchPivotCategory(id = 10, label = "Programmation", isSelected = false),
-                ),
+                pivot = initialPivot,
             )
+        val selectedScope = SearchCategoryScope.Category(id = 10, name = "Programmation")
         coEvery {
             repo.search(
                 SearchRequest(
                     query = "android",
-                    category = SearchCategoryScope.Category(id = 10, name = "Programmation"),
+                    category = selectedScope,
                 ),
             )
         } returns fakePage(
             topics = listOf(fakeTopic(99, "prog hit", cat = 10)),
-            pivot = listOf(
-                SearchPivotCategory(id = 1, label = "Hardware", isSelected = false),
-                SearchPivotCategory(id = 10, label = "Programmation", isSelected = true),
-            ),
+            pivot = emptyList(),
+            requestedCategory = selectedScope,
         )
 
         val vm = SearchViewModel(repo, initialPseudo = null)
@@ -247,8 +247,44 @@ class SearchViewModelTest {
         )
 
         val final = vm.state.value
+        assertEquals(initialPivot, final.pivotCategories)
         assertEquals(10, final.selectedCategory?.id)
         assertEquals("prog hit", final.results.first().title)
+    }
+
+    @Test
+    fun `Submit after category re-scope clears the preserved pivot when the fresh search has none`() = runTest {
+        val initialPivot = listOf(
+            SearchPivotCategory(id = 1, label = "Hardware", isSelected = true),
+            SearchPivotCategory(id = 10, label = "Programmation", isSelected = false),
+        )
+        val allCategoriesRequest = SearchRequest(query = "android", category = SearchCategoryScope.All)
+        coEvery { repo.search(allCategoriesRequest) } returnsMany listOf(
+            fakePage(topics = listOf(fakeTopic(1, "global hit", cat = 1)), pivot = initialPivot),
+            fakePage(topics = emptyList(), pivot = emptyList()),
+        )
+        val selectedScope = SearchCategoryScope.Category(id = 10, name = "Programmation")
+        coEvery {
+            repo.search(SearchRequest(query = "android", category = selectedScope))
+        } returns fakePage(
+            topics = listOf(fakeTopic(99, "prog hit", cat = 10)),
+            pivot = emptyList(),
+            requestedCategory = selectedScope,
+        )
+
+        val vm = SearchViewModel(repo, initialPseudo = null)
+        vm.submit(SearchIntent.QueryChanged("android"))
+        vm.submit(SearchIntent.Submit)
+        vm.submit(SearchIntent.CategorySelected(initialPivot.last()))
+        assertEquals(initialPivot, vm.state.value.pivotCategories)
+
+        vm.submit(SearchIntent.EditCriteria)
+        vm.submit(SearchIntent.Submit)
+
+        val final = vm.state.value
+        assertTrue(final.pivotCategories.isEmpty())
+        assertNull(final.selectedCategory)
+        assertTrue(final.results.isEmpty())
     }
 
     @Test
@@ -756,9 +792,10 @@ class SearchViewModelTest {
     private fun fakePage(
         topics: List<SearchTopicResult>,
         pivot: List<SearchPivotCategory>,
+        requestedCategory: SearchCategoryScope = SearchCategoryScope.All,
     ): SearchResultPage = SearchResultPage(
         query = "test",
-        requestedCategory = SearchCategoryScope.All,
+        requestedCategory = requestedCategory,
         selectedCategory = pivot.firstOrNull { it.isSelected },
         pivotCategories = pivot,
         topics = topics,


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Quoi

Fix du bug #918 (rapport sparko_dutos, TU) : la rangée d'onglets catégories de la recherche globale disparaissait après un changement de catégorie, jusqu'à re-soumission de la recherche.

## Cause & fix

Les réponses HFR en catégorie explicite n'embarquent pas le pivot de catégories (contrat parser, `Search.kt`). Le bloc succès de `launchSearch` écrasait alors `pivotCategories`/`selectedCategory` avec des listes vides. Le fix conserve le pivot découvert par la recherche toutes-catégories d'origine pour les réponses scoped sans pivot, et dérive l'onglet sélectionné de l'id du scope demandé. Une nouvelle recherche globale continue de remplacer le pivot (y compris par du vide).

## Process (mandat autonome 13/07)

- **Codé par GPT 5.6 Sol** (session codex workspace-write, worktree dédié), **relu et gaté par Claude Fable 5** — gates croisés demandés par XaTriX.
- 2 tests VM : bascule de catégorie conserve les onglets + sélection ; re-soumission globale vide bien le pivot conservé.
- Validation canonique verte : `detektAll :feature:search:testDebugUnitTest :feature:search:lintDebug` (BUILD SUCCESSFUL 4m52).

closes #918

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YiNthxW8eDCwbXrWjLNPh