### PR TITLE
fix(topic): édition/suppression de ses propres posts sous affichoutils=0 (#545)

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostOwnership.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/PostOwnership.kt
@@ -1,0 +1,22 @@
+package fr.forumhfr.redface2.feature.topic
+
+import fr.forumhfr.redface2.core.domain.blacklist.canonicalizePseudo
+import fr.forumhfr.redface2.core.model.Post
+
+/**
+ * #545 — session-aware post ownership.
+ *
+ * HFR profiles with « Affichage des outils » disabled (`affichoutils=0`) are served pages WITHOUT
+ * the per-post toolbar, so the parser cannot see the edit link and `Post.isEditable` /
+ * `Post.isOwnPost` both come back `false` even on the user's own posts. The author cell lives
+ * outside the toolbar and is always present, so comparing it against the connected session's
+ * pseudo is the reliable fallback. Canonical comparison mirrors the blacklist/profile matching
+ * (case- and whitespace-insensitive).
+ */
+internal fun isOwnPostBySession(post: Post, connectedPseudo: String?): Boolean =
+    !connectedPseudo.isNullOrBlank() &&
+        canonicalizePseudo(post.author) == canonicalizePseudo(connectedPseudo)
+
+/** Effective ownership : what the parser saw (toolbar) OR the session fallback (#545). */
+internal fun isOwnPostEffective(post: Post, connectedPseudo: String?): Boolean =
+    post.isOwnPost || isOwnPostBySession(post, connectedPseudo)

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1903,7 +1903,9 @@ private fun TopicLoadedContent(
             // Phase 2D (#147) — « Modifier » is exposed by HFR only on the
             // user's own posts of an unlocked topic. Same canReply gate as
             // Citer (#213) to refuse a read-only topic (no reply form).
-            val editAction: (() -> Unit)? = if (shouldShowEditAction(topic, post, state.isAuthenticated)) {
+            val editAction: (() -> Unit)? = if (
+                shouldShowEditAction(topic, post, state.isAuthenticated, state.connectedPseudo)
+            ) {
                 { onEdit(topic.subcat, topic.page, post.numreponse) }
             } else {
                 null
@@ -2024,7 +2026,7 @@ private fun TopicLoadedContent(
         val menuDeleteAction: (() -> Unit)? = if (
             state.deletingNumreponse == null &&
             !isFirstPostOfTopic(topic, post) &&
-            shouldShowDeleteAction(topic, post, state.isAuthenticated)
+            shouldShowDeleteAction(topic, post, state.isAuthenticated, state.connectedPseudo)
         ) {
             { onDeleteRequest(post.numreponse) }
         } else {
@@ -2036,7 +2038,7 @@ private fun TopicLoadedContent(
         // so its natural home is that post's contextual menu.
         val menuEditFirstPostAction: (() -> Unit)? = if (
             isFirstPostOfTopic(topic, post) &&
-            shouldShowEditFirstPost(topic, state.isAuthenticated)
+            shouldShowEditFirstPost(topic, state.isAuthenticated, state.connectedPseudo)
         ) {
             { onEditFirstPost(topic.subcat, topic.page, topic.posts.first().numreponse) }
         } else {
@@ -2061,7 +2063,9 @@ private fun TopicLoadedContent(
             },
             // #792 — « Envoyer un MP » : auth-gated, never on own posts, real profiles only
             // (« Publicité » rows are not messageable). Carries the author pseudo to `:app`.
-            onSendPrivateMessage = if (shouldShowSendPrivateMessage(post, state.isAuthenticated)) {
+            onSendPrivateMessage = if (
+                shouldShowSendPrivateMessage(post, state.isAuthenticated, state.connectedPseudo)
+            ) {
                 { onSendPrivateMessage(post.author) }
             } else {
                 null
@@ -2078,7 +2082,9 @@ private fun TopicLoadedContent(
             // either way `numreponse in hiddenNumreponses` tells whether the author is blacklisted, so
             // the entry flips between Masquer / Ne plus masquer. Hidden for the user's own posts.
             authorBlocked = post.numreponse in hiddenNumreponses,
-            onToggleBlockAuthor = if (post.isOwnPost) {
+            // #509 + #545 — never offer self-masking, including when the toolbar-blind parser
+            // could not flag the post as own (affichoutils=0 profiles).
+            onToggleBlockAuthor = if (isOwnPostEffective(post, state.connectedPseudo)) {
                 null
             } else {
                 { onSetAuthorBlocked(post.author, post.numreponse !in hiddenNumreponses) }
@@ -3530,11 +3536,25 @@ internal fun shouldShowQuoteAction(topic: Topic, isAuthenticated: Boolean): Bool
 // logged-in surface), never on the user's own posts, and only for authors with a real HFR
 // profile (`profileId != null` : « Publicité » rows and anonymous reads are not messageable —
 // same gate as the profile hero). Topic lock is irrelevant : the MP leaves the topic entirely.
-internal fun shouldShowSendPrivateMessage(post: Post, isAuthenticated: Boolean): Boolean =
-    isAuthenticated && !post.isOwnPost && post.profileId != null
+internal fun shouldShowSendPrivateMessage(
+    post: Post,
+    isAuthenticated: Boolean,
+    connectedPseudo: String?,
+): Boolean =
+    isAuthenticated && !isOwnPostEffective(post, connectedPseudo) && post.profileId != null
 
-internal fun shouldShowEditAction(topic: Topic, post: Post, isAuthenticated: Boolean): Boolean =
-    post.isEditable && topic.canReply && isAuthenticated
+// #545 — `post.isEditable` is blind when the profile disables « Affichage des outils »
+// (affichoutils=0 : HFR strips the whole toolbar), so ownership-by-pseudo is an OR-fallback.
+// HFR's edit form itself works regardless of the option — only the link was missing.
+internal fun shouldShowEditAction(
+    topic: Topic,
+    post: Post,
+    isAuthenticated: Boolean,
+    connectedPseudo: String?,
+): Boolean =
+    (post.isEditable || isOwnPostBySession(post, connectedPseudo)) &&
+        topic.canReply &&
+        isAuthenticated
 
 // #292 — « Supprimer » shares the « Modifier » gate: HFR exposes deletion through the same edit
 // form, so any post the user can edit, they can delete. The first-post exclusion (deleting it would
@@ -3548,8 +3568,15 @@ internal fun shouldShowEditAction(topic: Topic, post: Post, isAuthenticated: Boo
 internal fun shouldShowLastReadMarker(request: TopicRequest, numreponse: Int): Boolean =
     request.forceRefresh && request.scrollTo == numreponse
 
-internal fun shouldShowDeleteAction(topic: Topic, post: Post, isAuthenticated: Boolean): Boolean =
-    post.isEditable && topic.canReply && isAuthenticated
+internal fun shouldShowDeleteAction(
+    topic: Topic,
+    post: Post,
+    isAuthenticated: Boolean,
+    connectedPseudo: String?,
+): Boolean =
+    (post.isEditable || isOwnPostBySession(post, connectedPseudo)) &&
+        topic.canReply &&
+        isAuthenticated
 
 // #292 — the topic's first post is `topic.posts.first()` on page 1. Deleting it would remove the whole
 // topic (out of scope for this MVP), so the call site excludes it from the delete affordance. Position
@@ -3561,10 +3588,19 @@ internal fun isFirstPostOfTopic(topic: Topic, post: Post): Boolean =
 // Phase 2D #148 / #220 — « Modifier le premier message ». 6-way conjunction by design: auth,
 // FP ownership, postable topic, a real sub-category (FP recategorise is NOT relaxed for subcat=0,
 // cf. #213), page 1 (the FP lives there), non-empty posts. Each clause guards a distinct invariant.
+// #545 — `isFirstPostOwner` is parser-derived from the FIRST post's edit link, itself absent for
+// affichoutils=0 profiles ; ownership-by-pseudo of that same first post is the OR-fallback.
 @Suppress("ComplexCondition")
-internal fun shouldShowEditFirstPost(topic: Topic, isAuthenticated: Boolean): Boolean =
+internal fun shouldShowEditFirstPost(
+    topic: Topic,
+    isAuthenticated: Boolean,
+    connectedPseudo: String?,
+): Boolean =
     isAuthenticated &&
-        topic.isFirstPostOwner &&
+        (
+            topic.isFirstPostOwner ||
+                topic.posts.firstOrNull()?.let { isOwnPostBySession(it, connectedPseudo) } == true
+            ) &&
         topic.canReply &&
         topic.subcat > 0 &&
         topic.page == 1 &&

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
@@ -21,6 +21,13 @@ data class TopicUiState(
      */
     val isAuthenticated: Boolean = false,
     /**
+     * #545 — pseudo of the authenticated session, `null` while anonymous. Feeds the ownership
+     * fallback [isOwnPostBySession] : profiles with `affichoutils=0` get no post toolbar from
+     * HFR, so `Post.isEditable`/`Post.isOwnPost` are blind there and the gates need the session
+     * pseudo to recognise the user's own posts by author instead.
+     */
+    val connectedPseudo: String? = null,
+    /**
      * #292 — `numreponse` of the post whose deletion is currently in flight, or `null` when no
      * delete is running. Drives the per-post « Supprimer » affordance (disabled / busy) and guards
      * against a double-submit. Cleared when the delete settles (success or failure).

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModel.kt
@@ -291,7 +291,14 @@ class TopicViewModel @AssistedInject constructor(
         // at submit. Symmetric with the « Créer topic » FAB (CategoryViewModel.canCreateTopic).
         authRepository.observeAuthState()
             .onEach { authState ->
-                _state.update { it.copy(isAuthenticated = authState is AuthState.Authenticated) }
+                _state.update {
+                    it.copy(
+                        isAuthenticated = authState is AuthState.Authenticated,
+                        // #545 — carry the session pseudo for the ownership fallback (profiles
+                        // with affichoutils=0 get no toolbar : isEditable/isOwnPost are blind).
+                        connectedPseudo = (authState as? AuthState.Authenticated)?.pseudo,
+                    )
+                }
             }
             .launchIn(viewModelScope)
         // Build 89 follow-up — mirror the top-bar auto-hide preference into state so the screen
@@ -1164,7 +1171,9 @@ class TopicViewModel @AssistedInject constructor(
         // sub-category, cf. EditPostContext), so only the SUBCAT_UNKNOWN sentinel (-1) is rejected.
         val post = topic.posts.firstOrNull { it.numreponse == numreponse }
         val isFirstPost = topic.page == 1 && numreponse == topic.posts.firstOrNull()?.numreponse
-        if (post != null && !isFirstPost && post.isEditable && topic.canReply &&
+        val ownedPost = post != null &&
+            (post.isEditable || isOwnPostBySession(post, _state.value.connectedPseudo))
+        if (ownedPost && !isFirstPost && topic.canReply &&
             _state.value.isAuthenticated && topic.subcat >= 0
         ) {
             runDeletion(numreponse, topic.subcat)

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicActionGatesTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicActionGatesTest.kt
@@ -64,12 +64,53 @@ class TopicActionGatesTest {
         val postable = topic(canReply = true, posts = listOf(editablePost))
         val readOnly = topic(canReply = false, posts = listOf(editablePost))
 
-        assertTrue(shouldShowEditAction(postable, editablePost, isAuthenticated = true))
-        assertFalse(shouldShowEditAction(readOnly, editablePost, isAuthenticated = true))
-        assertFalse(shouldShowEditAction(topic(canReply = true), post(isEditable = false), isAuthenticated = true))
+        assertTrue(shouldShowEditAction(postable, editablePost, isAuthenticated = true, connectedPseudo = null))
+        assertFalse(shouldShowEditAction(readOnly, editablePost, isAuthenticated = true, connectedPseudo = null))
+        assertFalse(
+            shouldShowEditAction(
+                topic(canReply = true),
+                post(isEditable = false),
+                isAuthenticated = true,
+                connectedPseudo = null,
+            ),
+        )
         assertFalse(
             "#220 — logged-out must never see edit, even on a stale canReply=true row",
-            shouldShowEditAction(postable, editablePost, isAuthenticated = false),
+            shouldShowEditAction(postable, editablePost, isAuthenticated = false, connectedPseudo = null),
+        )
+    }
+
+    @Test
+    fun `edit action falls back to ownership-by-pseudo when the toolbar is absent (#545)`() {
+        // affichoutils=0 : HFR strips the toolbar → the parser reports isEditable=false even on
+        // the user's own posts. The session pseudo recognises them by author instead.
+        val blindOwnPost = post(isEditable = false)
+        val postable = topic(canReply = true, posts = listOf(blindOwnPost))
+
+        assertTrue(
+            "own post recognised by pseudo despite a missing edit link",
+            shouldShowEditAction(postable, blindOwnPost, isAuthenticated = true, connectedPseudo = "XaTriX"),
+        )
+        assertTrue(
+            "pseudo comparison is canonical (case-insensitive)",
+            shouldShowEditAction(postable, blindOwnPost, isAuthenticated = true, connectedPseudo = "xatrix"),
+        )
+        assertFalse(
+            "someone else's post stays non-editable",
+            shouldShowEditAction(postable, blindOwnPost, isAuthenticated = true, connectedPseudo = "muzah"),
+        )
+        assertFalse(
+            "the fallback never overrides the topic lock",
+            shouldShowEditAction(
+                topic(canReply = false, posts = listOf(blindOwnPost)),
+                blindOwnPost,
+                isAuthenticated = true,
+                connectedPseudo = "XaTriX",
+            ),
+        )
+        assertTrue(
+            "delete shares the fallback",
+            shouldShowDeleteAction(postable, blindOwnPost, isAuthenticated = true, connectedPseudo = "XaTriX"),
         )
     }
 
@@ -79,15 +120,23 @@ class TopicActionGatesTest {
         val postable = topic(canReply = true, posts = listOf(editablePost))
         val readOnly = topic(canReply = false, posts = listOf(editablePost))
 
-        assertTrue(shouldShowDeleteAction(postable, editablePost, isAuthenticated = true))
-        assertFalse("read-only topic", shouldShowDeleteAction(readOnly, editablePost, isAuthenticated = true))
+        assertTrue(shouldShowDeleteAction(postable, editablePost, isAuthenticated = true, connectedPseudo = null))
+        assertFalse(
+            "read-only topic",
+            shouldShowDeleteAction(readOnly, editablePost, isAuthenticated = true, connectedPseudo = null),
+        )
         assertFalse(
             "non-editable post (not the author / no edit link)",
-            shouldShowDeleteAction(topic(canReply = true), post(isEditable = false), isAuthenticated = true),
+            shouldShowDeleteAction(
+                topic(canReply = true),
+                post(isEditable = false),
+                isAuthenticated = true,
+                connectedPseudo = null,
+            ),
         )
         assertFalse(
             "#220 — logged-out must never see delete, even on a stale canReply=true row",
-            shouldShowDeleteAction(postable, editablePost, isAuthenticated = false),
+            shouldShowDeleteAction(postable, editablePost, isAuthenticated = false, connectedPseudo = null),
         )
     }
 
@@ -117,26 +166,55 @@ class TopicActionGatesTest {
         val fp = post(isEditable = true)
         val ready = topic(canReply = true, posts = listOf(fp), isFirstPostOwner = true, subcat = 550, page = 1)
 
-        assertTrue(shouldShowEditFirstPost(ready, isAuthenticated = true))
+        assertTrue(shouldShowEditFirstPost(ready, isAuthenticated = true, connectedPseudo = null))
         assertFalse(
             "#220 — logged-out never sees Modifier-FP, even on a stale postable row",
-            shouldShowEditFirstPost(ready, isAuthenticated = false),
+            shouldShowEditFirstPost(ready, isAuthenticated = false, connectedPseudo = null),
         )
         assertFalse(
             "not the FP owner",
-            shouldShowEditFirstPost(ready.copy(isFirstPostOwner = false), isAuthenticated = true),
+            shouldShowEditFirstPost(
+                ready.copy(isFirstPostOwner = false),
+                isAuthenticated = true,
+                connectedPseudo = null,
+            ),
         )
         assertFalse(
             "#213 — FP recategorise is not relaxed for subcat=0 (IA-style cat)",
-            shouldShowEditFirstPost(ready.copy(subcat = 0), isAuthenticated = true),
+            shouldShowEditFirstPost(ready.copy(subcat = 0), isAuthenticated = true, connectedPseudo = null),
         )
         assertFalse(
             "FP lives on page 1 only",
-            shouldShowEditFirstPost(ready.copy(page = 2, totalPages = 2), isAuthenticated = true),
+            shouldShowEditFirstPost(
+                ready.copy(page = 2, totalPages = 2),
+                isAuthenticated = true,
+                connectedPseudo = null,
+            ),
         )
         assertFalse(
             "read-only topic",
-            shouldShowEditFirstPost(ready.copy(canReply = false), isAuthenticated = true),
+            shouldShowEditFirstPost(ready.copy(canReply = false), isAuthenticated = true, connectedPseudo = null),
+        )
+    }
+
+    @Test
+    fun `edit-first-post falls back to ownership-by-pseudo of the first post (#545)`() {
+        // isFirstPostOwner is parser-derived from the FP's edit link — absent for affichoutils=0.
+        val blind = topic(
+            canReply = true,
+            posts = listOf(post(isEditable = false)),
+            isFirstPostOwner = false,
+            subcat = 550,
+            page = 1,
+        )
+
+        assertTrue(
+            "FP owned by pseudo despite a toolbar-blind parse",
+            shouldShowEditFirstPost(blind, isAuthenticated = true, connectedPseudo = "XaTriX"),
+        )
+        assertFalse(
+            "someone else's FP stays locked",
+            shouldShowEditFirstPost(blind, isAuthenticated = true, connectedPseudo = "muzah"),
         )
     }
 
@@ -146,22 +224,31 @@ class TopicActionGatesTest {
 
         assertTrue(
             "#792 — authenticated + someone else's profiled post exposes « Envoyer un MP »",
-            shouldShowSendPrivateMessage(other, isAuthenticated = true),
+            shouldShowSendPrivateMessage(other, isAuthenticated = true, connectedPseudo = null),
         )
         assertFalse(
             "#220 — logged-out must never see « Envoyer un MP »",
-            shouldShowSendPrivateMessage(other, isAuthenticated = false),
+            shouldShowSendPrivateMessage(other, isAuthenticated = false, connectedPseudo = null),
         )
         assertFalse(
             "no MP to oneself",
             shouldShowSendPrivateMessage(
                 post(profileId = 123, isOwnPost = true),
                 isAuthenticated = true,
+                connectedPseudo = null,
+            ),
+        )
+        assertFalse(
+            "#545 — no MP to oneself either when only the pseudo reveals ownership",
+            shouldShowSendPrivateMessage(
+                post(profileId = 123, isOwnPost = false),
+                isAuthenticated = true,
+                connectedPseudo = "XaTriX",
             ),
         )
         assertFalse(
             "profile-less rows (« Publicité », anonymous reads) are not messageable",
-            shouldShowSendPrivateMessage(post(profileId = null), isAuthenticated = true),
+            shouldShowSendPrivateMessage(post(profileId = null), isAuthenticated = true, connectedPseudo = null),
         )
     }
 

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -545,6 +545,50 @@ class TopicViewModelTest {
     }
 
     @Test
+    fun `state carries the connected pseudo for the ownership fallback (#545)`() = runTest {
+        val auth = FakeAuthRepository(AuthState.Authenticated("xaat"))
+        val vm = topicViewModel(
+            request = topicRequest(page = 1),
+            topicRepository = FakeTopicRepository(flowsToReturn = listOf(flow { emit(fakeTopic(1, 1)) })),
+            authRepository = auth,
+        )
+        assertEquals("xaat", vm.state.value.connectedPseudo)
+
+        auth.emit(AuthState.Anonymous) // logout → the fallback must stop matching anything
+        assertEquals(null, vm.state.value.connectedPseudo)
+    }
+
+    @Test
+    fun `DeletePost proceeds for an own-by-pseudo post without an edit link (#545)`() = runTest {
+        // affichoutils=0 : the toolbar (and its edit link) is absent, so isEditable=false even on
+        // the user's own post. Ownership-by-pseudo must let the deletion through.
+        val loaded = fakeTopic(
+            page = 2,
+            totalPages = 3,
+            posts = listOf(fakePost(numreponse = 777, isEditable = false, author = "xaat")),
+        )
+        val refreshed = fakeTopic(page = 2, totalPages = 3, title = "refreshed")
+        val repository = FakeTopicRepository(
+            flowsToReturn = listOf(flow { emit(loaded) }),
+            refreshTopicsToReturn = listOf(refreshed),
+        )
+        val deleteRepo = FakeDeletePostRepository(DeletePostResult.Success(deletedWholeTopic = false))
+        val viewModel = topicViewModel(
+            request = topicRequest(page = 2),
+            topicRepository = repository,
+            authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
+            deletePostRepository = deleteRepo,
+        )
+
+        viewModel.effects.test {
+            viewModel.send(TopicIntent.DeletePost(777))
+            assertEquals(TopicEffect.PostDeleted, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(777, deleteRepo.calls.single().numreponse)
+    }
+
+    @Test
     fun `state topBarAutoHide reflects the user preference (build 89)`() = runTest {
         val on = topicViewModel(
             request = topicRequest(page = 1),


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Quoi

Fix #545 (rapport muzah) : « Éditer »/« Supprimer » absents sur ses propres posts quand le profil HFR a « Affichage des outils » désactivée — HFR ne sert alors AUCUNE toolbar de post, le parser ne voit pas le lien d'édition, `isEditable`/`isOwnPost` restent `false`. Cause reproduite live sur le compte agent (bascule de l'option → toolbar disparaît/réapparaît).

## Fix

Fallback « ownership par pseudo » (comparaison canonique, helper partagé avec la blacklist) au niveau des **gates session-aware** — pas au parser (pur HTML→modèle) ni au repo (posts cachés Room) :
- `shouldShowEditAction` / `shouldShowDeleteAction` / `shouldShowEditFirstPost` : OR-fallback ;
- gardes symétriques : pas de MP à soi-même, pas d'auto-masquage (`isOwnPostEffective`) ;
- revalidation VM de `DeletePost` assouplie pareil (le serveur reste l'autorité finale) ;
- `TopicUiState.connectedPseudo` alimenté par `observeAuthState()`.

Le flux d'édition ne consomme pas le lien parsé (URL reconstruite de cat/subcat/post/page/numreponse) → aucun autre changement.

## Trade-off tracé (pré-existant, non aggravé)

Les caches de pages topic ne sont pas per-user (KDoc `CacheInvalidator`) : un `isEditable` périmé peut survivre à un switch de compte pendant le TTL de 60 s. Le fallback pseudo, lui, ne matche que le pseudo de la session **courante**. Cas modérateur préservé (le lien d'édition sur les posts d'autrui reste l'autorité via `isEditable`).

## Gates

Sol xhigh : NO-GO round 1 (exigeait pseudo=autorité) → **GO round 2** sur contre-faits (cas modérateur + TTL 60 s documenté). Validation canonique verte : `detektAll :feature:topic:testDebugUnitTest :feature:topic:lintDebug`. Tests : 2 nouveaux blocs gates (#545), plomberie pseudo + delete own-by-pseudo côté VM.

Issue de suivi à ficher : `profileId`/`quoteRef` null pour TOUS les posts sous affichoutils=0 (tap profil inerte, ref de citation absent).

closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YiNthxW8eDCwbXrWjLNPh