### PR TITLE
fix(parser): lignes vides alignées sur le contrat web HFR (#532)

### DIFF
--- a/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
+++ b/core/parser/src/main/kotlin/fr/forumhfr/redface2/core/parser/PostContentParser.kt
@@ -101,12 +101,11 @@ class PostContentParser {
             pendingParagraph = false
         }
 
-        // #466 — count of orphan `&nbsp;` (U+00A0) carried by the last top-level whitespace-only
-        // text node, kept pending until we know what follows it. HFR always emits at LEAST one
-        // `&nbsp;` between two sibling <p> (the structural paragraph separator, ~all pages), and
-        // an EXTRA `&nbsp;` for each blank line the author typed in between. So a run of N drives
-        // (N - 1) rendered empty lines ; a lone separator (N == 1) keeps the current behaviour
-        // (two distinct Paragraph blocks). See `parseParagraphContainer`.
+        // #466/#532 — count of orphan `&nbsp;` (U+00A0) carried by the last top-level
+        // whitespace-only text node, kept pending until we know what follows it. Live captures for
+        // #532 establish that EVERY `&nbsp;` between two sibling <p> represents one visible blank
+        // line; a leading <br> in the following <p> represents one more. See
+        // `parseParagraphContainer` for the AST newline conversion.
         var pendingNbsp = 0
 
         nodes.forEach { node ->
@@ -197,24 +196,22 @@ class PostContentParser {
     }
 
     /**
-     * #466 — folds the orphan `&nbsp;` run separating two `<p>` into rendered empty lines.
+     * #466/#532 — folds the orphan `&nbsp;` run separating two `<p>` into rendered empty lines.
      *
-     * HFR encodes a deliberate blank line BETWEEN two paragraphs as an EXTRA `&nbsp;` in the
-     * orphan text node separating the two `<p>` (the very first `&nbsp;` is the structural
-     * separator HFR always emits between any two sibling `<p>`). The parser used to swallow that
-     * whitespace and emit each `<p>` as its own Paragraph block, losing the empty lines (the
-     * "lignes sautées" bug, suite of #333/#280 — the earlier fix only covered the
-     * `<br />&nbsp;<br />` shape, not the `</p>&nbsp;…&nbsp;<p>` one).
+     * Live HFR captures for #532 establish the server contract: every orphan `&nbsp;` between two
+     * sibling `<p>` is one visible blank line, and a `<br>` at the very start of the following `<p>`
+     * adds one more. Compose renders N [PostInline.LineBreak] nodes between non-empty text lines as
+     * N - 1 empty typographic lines, so the AST needs one boundary break in addition to the visible
+     * blank-line count.
      *
      * An inline-only `<p>` (HFR never nests a block table/container directly inside a `<p>`,
      * verified across the fixtures) is accumulated into the running paragraph buffer rather than
      * sub-parsed, so the NEXT `<p>` can decide to merge with it:
-     *  - when at least one EXTRA `&nbsp;` is pending (run ≥ 2) and the running paragraph already
-     *    holds real content, the boundary is kept inside ONE paragraph as [pendingNbsp] LineBreaks
-     *    — one for the paragraph boundary itself plus (pendingNbsp - 1) for the authored empty
-     *    lines. They sit strictly between two text runs, so the #333 edge-trim never touches them.
-     *  - otherwise (lone `&nbsp;` separator, or an empty running paragraph) the running paragraph
-     *    is flushed first, so two ordinary paragraphs stay two distinct Paragraph blocks as before.
+     *  - when at least one `&nbsp;` is pending and the running paragraph already holds real content,
+     *    the two `<p>` bodies are kept in ONE paragraph. The separator contributes
+     *    `pendingNbsp + 1` LineBreaks, plus one if the next `<p>` starts with `<br>`.
+     *  - otherwise (no `&nbsp;`, or an empty running paragraph) the running paragraph is flushed
+     *    first, so unrelated paragraphs stay distinct blocks.
      *
      * A `<p>` that does carry a nested block keeps the legacy path: flush, then sub-parse so the
      * inner block surfaces.
@@ -240,7 +237,7 @@ class PostContentParser {
         // Only fold the `&nbsp;` separator into empty lines when the buffer is genuinely the body of
         // a PREVIOUS inline-only <p> ([pendingParagraph]) — NOT arbitrary buffered inline content.
         // `<strong>A</strong>&nbsp;&nbsp;<p>B</p>` must stay two blocks, not merge (#466 Codex review).
-        val mergeable = pendingNbsp >= 2 && pendingParagraph && paragraph.any { it.isNonBlank() }
+        val mergeable = pendingNbsp > 0 && pendingParagraph && paragraph.any { it.isNonBlank() }
         if (mergeable) {
             // #466 (Codex review) — drop a trailing border <br> on the first paragraph so its edge
             // break does not pile onto the separator breaks below (the legacy sub-parse edge-trimmed
@@ -248,7 +245,9 @@ class PostContentParser {
             while (paragraph.isNotEmpty() && paragraph.last().isBlankOrBreak()) {
                 paragraph.removeAt(paragraph.lastIndex)
             }
-            repeat(pendingNbsp) { paragraph += PostInline.LineBreak }
+            val leadingParagraphBreak = children.firstOrNull().isLineBreakElement()
+            val separatorBreakCount = pendingNbsp + 1 + if (leadingParagraphBreak) 1 else 0
+            repeat(separatorBreakCount) { paragraph += PostInline.LineBreak }
         } else {
             // Close the previous paragraph as its own block, then accumulate this <p>'s inline
             // content into the now-empty buffer so a following <p> can still merge with it (#466).
@@ -256,9 +255,9 @@ class PostContentParser {
         }
         // Accumulate the <p> body inline, honouring the same per-node classification as the block
         // path: a nested <br> stays a LineBreak and an ignored node (e.g. a `clear: both` spacer
-        // div) is dropped. EDGE-trim leading/trailing breaks (#466 Codex review): the real fixture
-        // has `<p><br />Pour…`, whose leading border <br> would otherwise render an extra empty line
-        // — only INTERIOR breaks (the author's line structure) survive, matching flushParagraph #333.
+        // div) is dropped. EDGE-trim leading/trailing breaks (#466 Codex review): a leading <br> is
+        // represented exactly once in separatorBreakCount when paragraphs merge, while unrelated
+        // paragraph edges keep the legacy trim. Only INTERIOR breaks remain in the parsed body.
         val merged = buildList {
             children.forEach { child ->
                 when (classifyNode(child)) {
@@ -304,11 +303,11 @@ class PostContentParser {
 
     private fun classifyNonElement(node: Node): NodeKind = when {
         node !is TextNode -> NodeKind.IGNORE
-        // #466 — a whitespace-only text node carrying at least one `&nbsp;` (U+00A0) is HFR's
-        // inter-paragraph separator, possibly inflated with one extra `&nbsp;` per authored empty
-        // line. It is BLANK_TEXT so parseBlocks can fold the run into rendered line breaks instead
-        // of swallowing it. A whitespace text node WITHOUT `&nbsp;` stays INLINE: it is genuine
-        // word spacing inside a paragraph and must survive between two text runs.
+        // #466/#532 — a whitespace-only text node carrying at least one `&nbsp;` (U+00A0) can be
+        // HFR's compressed inter-paragraph empty-line run. It is BLANK_TEXT so parseBlocks can defer
+        // the decision until it sees the following node. A whitespace text node WITHOUT `&nbsp;`
+        // stays INLINE: it is genuine word spacing inside a paragraph and must survive between two
+        // text runs.
         node.wholeText.isBlank() && node.wholeText.any { it == NBSP } -> NodeKind.BLANK_TEXT
         else -> NodeKind.INLINE
     }

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserEmptyLinesTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserEmptyLinesTest.kt
@@ -1,0 +1,92 @@
+package fr.forumhfr.redface2.core.parser
+
+import fr.forumhfr.redface2.core.model.PostBlock
+import fr.forumhfr.redface2.core.model.PostInline
+import org.jsoup.Jsoup
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PostContentParserEmptyLinesTest {
+    @Test
+    fun `intra-paragraph br between M0 and M1 stays a direct line break`() {
+        assertBlankLinesBetween(FIXTURE_RUNS_1_6, "M0", "M1", expectedBlankLines = 0)
+    }
+
+    @Test
+    fun `one source empty line renders one web empty line`() {
+        assertBlankLinesBetween(FIXTURE_RUNS_1_6, "M1", "M2", expectedBlankLines = 1)
+    }
+
+    @Test
+    fun `two source empty lines render two web empty lines`() {
+        assertBlankLinesBetween(FIXTURE_RUNS_1_6, "M2", "M3", expectedBlankLines = 2)
+    }
+
+    @Test
+    fun `three source empty lines render two web empty lines`() {
+        assertBlankLinesBetween(FIXTURE_RUNS_1_6, "M3", "M4", expectedBlankLines = 2)
+    }
+
+    @Test
+    fun `four source empty lines render three web empty lines`() {
+        assertBlankLinesBetween(FIXTURE_RUNS_1_6, "M4", "M5", expectedBlankLines = 3)
+    }
+
+    @Test
+    fun `five source empty lines render three web empty lines`() {
+        assertBlankLinesBetween(FIXTURE_RUNS_5_10, "M7", "M8", expectedBlankLines = 3)
+    }
+
+    @Test
+    fun `six source empty lines render four web empty lines`() {
+        assertBlankLinesBetween(FIXTURE_RUNS_1_6, "M5", "M6", expectedBlankLines = 4)
+    }
+
+    @Test
+    fun `ten source empty lines render six web empty lines without a cap`() {
+        assertBlankLinesBetween(FIXTURE_RUNS_5_10, "M8", "M9", expectedBlankLines = 6)
+    }
+
+    private fun assertBlankLinesBetween(
+        fixtureName: String,
+        fromMarker: String,
+        toMarker: String,
+        expectedBlankLines: Int,
+    ) {
+        val inlines = parseFixtureParagraph(fixtureName)
+        val fromIndex = inlines.indexOfFirst { it == PostInline.Text(fromMarker) }
+        val toIndex = inlines.indexOfFirst { it == PostInline.Text(toMarker) }
+        assertTrue(
+            "missing or reversed markers $fromMarker/$toMarker in $inlines",
+            fromIndex >= 0 && toIndex > fromIndex,
+        )
+
+        val lineBreaks = inlines.subList(fromIndex + 1, toIndex).count { it is PostInline.LineBreak }
+        assertEquals(
+            "$fixtureName $fromMarker->$toMarker: Text needs one boundary break plus " +
+                "$expectedBlankLines empty lines",
+            expectedBlankLines + 1,
+            lineBreaks,
+        )
+    }
+
+    private fun parseFixtureParagraph(fixtureName: String): List<PostInline> {
+        val html = requireNotNull(javaClass.getResource("/fixtures/$fixtureName")) {
+            "Fixture not found: $fixtureName"
+        }.readText()
+        val document = Jsoup.parseBodyFragment("<div id=\"para532\">$html</div>")
+        val contentElement = requireNotNull(document.selectFirst("div#para532"))
+        val paragraphs = PostContentParser()
+            .parse(contentElement)
+            .ast.blocks
+            .filterIsInstance<PostBlock.Paragraph>()
+        assertEquals("all marker paragraphs must fold into one text block", 1, paragraphs.size)
+        return paragraphs.single().inlines
+    }
+
+    private companion object {
+        const val FIXTURE_RUNS_1_6 = "fixture-532-runs-1-6.html"
+        const val FIXTURE_RUNS_5_10 = "fixture-532-runs-5-10.html"
+    }
+}

--- a/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
+++ b/core/parser/src/test/kotlin/fr/forumhfr/redface2/core/parser/PostContentParserTest.kt
@@ -478,9 +478,9 @@ class PostContentParserTest {
 
     @Test
     fun `orphan nbsp runs between paragraphs survive as empty lines (real fixture)`() {
-        // #466 — suite of #333/#280. HFR encodes a deliberate blank line BETWEEN two paragraphs
-        // not as `<br /><br />` (the shape #423 already handled) but as an EXTRA `&nbsp;` inside
-        // the orphan text node separating two sibling <p>. Real witness on the single-page topic
+        // #466 — suite of #333/#280. HFR also encodes blank lines BETWEEN two paragraphs through
+        // the orphan `&nbsp;` text node separating sibling <p>, rather than the `<br /><br />`
+        // shape #423 already handled. Real witness on the single-page topic
         // (post #9762063, captured fixture): `…C'est normal.</p>&nbsp;&nbsp;&nbsp;<p><br />Pour
         // trouver une solution…</p>` — 3 `&nbsp;` between the two paragraphs. The parser used to
         // swallow that whitespace and emit two separate Paragraph blocks, losing the blank lines.
@@ -506,9 +506,8 @@ class PostContentParserTest {
             paragraph.inlines.filterIsInstance<PostInline.Text>()
                 .any { it.value.contains("C'est normal.") },
         )
-        // The triple `&nbsp;` run folds into blank lines (>= 2 LineBreaks) between the two authored
-        // lines; the exact count for a bare run is pinned by the synthetic test below. A lone
-        // `&nbsp;` separator never folds, so >= 2 here proves the multi-nbsp blank lines survived.
+        // The triple `&nbsp;` run folds into blank lines between the two authored lines; the exact
+        // count for a bare run is pinned by the synthetic test below.
         val breaksBetween = run {
             val inlines = paragraph.inlines
             val from = inlines.indexOfLast {
@@ -519,14 +518,13 @@ class PostContentParserTest {
             }
             inlines.subList(from + 1, to).count { it is PostInline.LineBreak }
         }
-        // EXACTLY 3: the triple `&nbsp;` run yields 3 separator breaks (1 boundary + 2 empty lines).
-        // The second <p> opens with a border `<br />` (`<p><br />Pour…`) which must be edge-trimmed
-        // (#466 Codex review) — were it kept it would push this to 4 and render a spurious 3rd empty
-        // line. Pinning the exact count guards that border-break trim on the real fixture.
+        // #532 live contract: 3 `&nbsp;` + the following paragraph's leading `<br />` represent
+        // 4 visible empty lines. Text needs 5 newline characters to leave 4 empty lines between the
+        // two non-empty lines.
         assertEquals(
-            "the triple orphan &nbsp; run must yield EXACTLY 3 LineBreaks (border <br> trimmed), " +
+            "3 orphan &nbsp; plus the leading <br> must yield exactly 5 LineBreaks, " +
                 "got=$breaksBetween",
-            3,
+            5,
             breaksBetween,
         )
     }
@@ -552,11 +550,10 @@ class PostContentParserTest {
     }
 
     @Test
-    fun `merging paragraphs trims border breaks but keeps separator breaks - 466 codex`() {
-        // #466 (Codex review) — when two <p> merge over a >=2 `&nbsp;` run, a trailing `<br>` on the
-        // first <p> and a leading `<br>` on the second are BORDER breaks (the legacy sub-parse
-        // edge-trimmed them via flushParagraph). Only the separator breaks (here 2) plus any INTERIOR
-        // break survive. DERIVED FROM the issue #466 encoding, not a raw hfr-mcp capture.
+    fun `merging paragraphs trims trailing border break and counts leading break - 466 532`() {
+        // #466/#532 — a trailing `<br>` on the first <p> remains a border break and is trimmed. The
+        // leading `<br>` on the second <p> is part of HFR's captured empty-line contract and adds one
+        // visible line. DERIVED FROM the issue encoding, not a raw hfr-mcp capture.
         val parser = PostContentParser()
         val element = jsoupBody(
             "<div id=\"para1\"><p>A<br /></p>&nbsp;&nbsp;<p><br />B</p></div>",
@@ -571,9 +568,11 @@ class PostContentParserTest {
             paragraphs.size,
         )
         assertEquals(
-            "2 orphan &nbsp; ⇒ 2 separator LineBreaks; the border <br>s of both <p> are trimmed",
+            "2 nbsp + 1 leading br represent 3 empty lines and require 4 LineBreaks",
             listOf(
                 PostInline.Text("A"),
+                PostInline.LineBreak,
+                PostInline.LineBreak,
                 PostInline.LineBreak,
                 PostInline.LineBreak,
                 PostInline.Text("B"),
@@ -667,11 +666,10 @@ class PostContentParserTest {
     }
 
     @Test
-    fun `single orphan nbsp between paragraphs stays two separate blocks`() {
-        // #466 guard — a LONE `&nbsp;` between two <p> is HFR's normal paragraph separator (it is
-        // present between ~every pair of sibling <p>), NOT an authored blank line. Folding it in
-        // would add a spurious empty line to virtually every multi-paragraph post, so the parser
-        // must keep two distinct Paragraph blocks in that case (legacy behaviour preserved).
+    fun `single orphan nbsp between paragraphs renders one empty line`() {
+        // #532 supersedes the old #466 assumption that a lone `&nbsp;` was structural only. The live
+        // server contract proves it represents one visible blank line, so the paragraphs merge with
+        // 2 LineBreaks (one boundary + one empty typographic line).
         //
         // NOTE: this HTML input is DERIVED FROM THE ISSUE #466 encoding (`</p>&nbsp;<p>`), not a
         // raw hfr-mcp capture — it isolates the single-separator boundary so the fix can be pinned
@@ -686,12 +684,19 @@ class PostContentParserTest {
 
         val paragraphs = result.ast.blocks.filterIsInstance<PostBlock.Paragraph>()
         assertEquals(
-            "a lone &nbsp; separator must keep two distinct Paragraph blocks, got=${result.ast.blocks}",
-            2,
+            "a lone &nbsp; separator must merge the paragraphs, got=${result.ast.blocks}",
+            1,
             paragraphs.size,
         )
-        assertEquals("premier paragraphe", (paragraphs[0].inlines.single() as PostInline.Text).value)
-        assertEquals("second paragraphe", (paragraphs[1].inlines.single() as PostInline.Text).value)
+        assertEquals(
+            listOf(
+                PostInline.Text("premier paragraphe"),
+                PostInline.LineBreak,
+                PostInline.LineBreak,
+                PostInline.Text("second paragraphe"),
+            ),
+            paragraphs.single().inlines,
+        )
     }
 
     @Test
@@ -699,8 +704,8 @@ class PostContentParserTest {
         // #466 — focused boundary check on the EXACT encoding documented in the issue:
         // `<p>A</p>&nbsp;&nbsp;&nbsp;<p>B</p>` (3 orphan `&nbsp;`). DERIVED FROM THE ISSUE #466
         // encoding, not a raw hfr-mcp capture (the real multi-run shape is also pinned by the
-        // `topic_page_single.html` fixture test above). A run of 3 ⇒ one paragraph boundary +
-        // two authored empty lines, kept as 3 LineBreaks inside ONE paragraph.
+        // `topic_page_single.html` fixture test above). #532 establishes 3 visible empty lines,
+        // represented by 4 LineBreaks between the two non-empty lines.
         val parser = PostContentParser()
         val element = jsoupBody(
             "<div id=\"para1\"><p>A</p>&nbsp;&nbsp;&nbsp;<p>B</p></div>",
@@ -710,14 +715,16 @@ class PostContentParserTest {
 
         val paragraphs = result.ast.blocks.filterIsInstance<PostBlock.Paragraph>()
         assertEquals(
-            "the two paragraphs separated by a >=2 nbsp run must merge into ONE block, got=${result.ast.blocks}",
+            "the two paragraphs separated by an nbsp run must merge into ONE block, " +
+                "got=${result.ast.blocks}",
             1,
             paragraphs.size,
         )
         assertEquals(
-            "3 orphan &nbsp; fold into 3 LineBreaks between A and B (1 boundary + 2 empty lines)",
+            "3 orphan &nbsp; represent 3 empty lines and require 4 LineBreaks between A and B",
             listOf(
                 PostInline.Text("A"),
+                PostInline.LineBreak,
                 PostInline.LineBreak,
                 PostInline.LineBreak,
                 PostInline.LineBreak,

--- a/core/parser/src/test/resources/fixtures/fixture-532-runs-1-6.html
+++ b/core/parser/src/test/resources/fixtures/fixture-532-runs-1-6.html
@@ -1,0 +1,1 @@
+<p>M0<br />M1</p>&nbsp;<p>M2</p>&nbsp;<p><br />M3</p>&nbsp;&nbsp;<p>M4</p>&nbsp;&nbsp;<p><br />M5</p>&nbsp;&nbsp;&nbsp;<p><br />M6</p>

--- a/core/parser/src/test/resources/fixtures/fixture-532-runs-1-6.source.txt
+++ b/core/parser/src/test/resources/fixtures/fixture-532-runs-1-6.source.txt
@@ -1,0 +1,5 @@
+Capture: forum.hardware.fr live, 2026-07-13
+Provenance: corps de post fourni par le mainteneur pour l'issue #532 ; URL, catégorie et numreponse non fournis.
+Contenu: runs source de 1, 2, 3, 4 et 6 lignes vides entre M1 et M6 ; M0/M1 vérifie le <br /> intra-paragraphe.
+Nettoyage: prose de fin retirée ; la séquence utile des balises <p>/<br /> et des &nbsp; est inchangée.
+Encodage: capture annoncée latin-1 ; contenu utile ASCII après nettoyage.

--- a/core/parser/src/test/resources/fixtures/fixture-532-runs-5-10.html
+++ b/core/parser/src/test/resources/fixtures/fixture-532-runs-5-10.html
@@ -1,0 +1,1 @@
+<p>M7</p>&nbsp;&nbsp;&nbsp;<p>M8</p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<p><br />M9<div style="clear: both;"> </div></p>

--- a/core/parser/src/test/resources/fixtures/fixture-532-runs-5-10.source.txt
+++ b/core/parser/src/test/resources/fixtures/fixture-532-runs-5-10.source.txt
@@ -1,0 +1,7 @@
+Capture: forum.hardware.fr live, 2026-07-13
+Provenance: corps de post fourni par le mainteneur pour l'issue #532 ; URL, catégorie et numreponse non fournis.
+Contenu: runs source de 5 lignes vides entre M7/M8 et de 10 lignes vides entre M8/M9.
+Nettoyage: aucun changement de structure ; les balises <p>/<br /> et les &nbsp; sont conservés tels que capturés,
+y compris le spacer <div style="clear: both;"> réel de fin de post et la fermeture </p> (la coupe initiale de la
+capture les avait tronqués — corrigé le 13/07 pour coller au HTML servi).
+Encodage: capture annoncée latin-1 ; contenu utile ASCII.


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Quoi

#532 était `status:blocked-capture` — débloquée aujourd'hui par **capture live du contrat serveur** (pipeline de rendu MP, deux captures avec provenance) : HFR **compresse** les runs de lignes vides, il ne les plafonne pas. n lignes vides sources → `ceil(n/2)` séparateurs `&nbsp;` entre `<p>` + un `<br>` de tête du paragraphe suivant si n pair = **floor(n/2)+1 lignes vides visibles**, sans plafond absolu (n=10 → 6).

## Découverte contre-intuitive

Le mapping #466 actuel **sous-rendait** les runs (il escomptait le premier `&nbsp;` comme séparateur structurel et trimait le `<br>` de tête) : n=1..2 → 0 ligne vide + gap de bloc 8 dp, n=10 → 4. L'hypothèse « l'app rend des trous plus gros que le web » de l'issue est réfutée par le calcul — la capture imgur d'origine mesurait probablement le gap de bloc vs la hauteur typographique.

## Fix

Chaque `&nbsp;` orphelin = 1 ligne vide visible, `<br>` de tête = +1, fenêtre de fusion dès `pendingNbsp >= 1`. Toutes les gardes #466 conservées (nbsp inline, contenu inline arbitraire, blocs imbriqués, edge-trims). `BbcodeContentParser` (aperçu éditeur) non concerné.

## Process (mandat autonome 13/07)

- Capture du contrat par Claude (MP live, marqueurs calibrés n=1,2,3,4,5,6,10), **codé par GPT 5.6 Sol** (codex workspace-write, worktree dédié), **relu/validé par Claude** — gates croisés.
- 8 tests unitaires dédiés (un par taille de run + non-régression `<br>` intra-paragraphe) sur les fixtures live ; 4 tests #466 adaptés explicitement au contrat live (détaillé dans le commit).
- Validation : `detektAll` ✔ + `:core:parser:test` ✔ (300 tests).
- Note reviewer : changement de rendu visible sur tout post multi-paragraphes (l'espacement authored-blank-lines suit désormais le web) — à mentionner dans le changelog de release.

closes #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YiNthxW8eDCwbXrWjLNPh