### PR TITLE
feat(editor): grille smileys plafonnée à 62 % de l'écran — feuille ≈ 3/4 (#900 volet 2)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerSheet.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/editor/SmileyPickerSheet.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -229,6 +230,14 @@ private fun WikiTabContent(
 
 @Composable
 private fun SmileyGrid(items: List<EditorSmiley>, onSmileyClicked: (String) -> Unit) {
+    // #900 volet 2 (CharLee, TU #2791061) — the grid cap scales with the screen so the sheet
+    // reaches ~3/4 of a phone display instead of the fixed 320 dp, which wasted the bottom half
+    // on tall screens. The 320 dp FLOOR keeps short screens (landscape, split-screen) exactly at
+    // the previous behaviour — the night gate's condition (Sol r1) : never LESS room than before,
+    // and the M3 sheet still clamps itself to the window insets beyond that. The fraction leaves
+    // headroom for the sheet chrome (tabs + search field), which grows with fontScale on its own.
+    val screenHeight = LocalConfiguration.current.screenHeightDp.dp
+    val gridHeightCap = maxOf(SMILEY_GRID_MIN_HEIGHT_CAP, screenHeight * SMILEY_GRID_SCREEN_FRACTION)
     LazyVerticalGrid(
         // #236 — denser grid: smaller min cell (was 64.dp) packs more smileys per row.
         columns = GridCells.Adaptive(minSize = 48.dp),
@@ -236,12 +245,7 @@ private fun SmileyGrid(items: List<EditorSmiley>, onSmileyClicked: (String) -> U
         verticalArrangement = Arrangement.spacedBy(8.dp),
         modifier = Modifier
             .fillMaxWidth()
-            // Cap the grid height inside the bottom sheet so it does not eat the whole
-            // screen on small devices ; the sheet's own scrollable container takes over
-            // beyond this point. #900 keeps this cap UNCHANGED for now (gate Sol r1 : raising
-            // it needs a short-screen + fontScale proof, émulateur requis) — the density gain
-            // ships as the removed title line.
-            .heightIn(max = 320.dp),
+            .heightIn(max = gridHeightCap),
     ) {
         items(items = items, key = { it.token to it.imageUrl }) { smiley ->
             SmileyCell(smiley = smiley, onClick = { onSmileyClicked(smiley.token) })
@@ -335,3 +339,12 @@ internal fun smileyCellImageSize(source: EditorSmileySource, measuredPx: IntSize
  * perso, and the per-axis cap of a measured one.
  */
 internal const val WIKI_CELL_IMAGE_SIZE_DP = 44
+
+/**
+ * #900 volet 2 — the grid's height budget : [SMILEY_GRID_SCREEN_FRACTION] of the screen height,
+ * floored at the historical 320 dp so short screens (landscape, split-screen) never get LESS grid
+ * than before. 0.62 of the height plus the sheet chrome (tabs, search field, paddings) lands the
+ * whole sheet around three quarters of a typical phone display (CharLee's ask, TU #2791061).
+ */
+private val SMILEY_GRID_MIN_HEIGHT_CAP = 320.dp
+private const val SMILEY_GRID_SCREEN_FRACTION = 0.62f


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

## Quoi

Volet 2 de #900 (retour CharLee, TU #2791061 : « le panneau smileys pourrait prendre les 3/4 de l'écran ») : le cap de hauteur de la grille passe de 320 dp fixes à **62 % de la hauteur d'écran, plancher 320 dp**.

## Preuves (dogfood émulateur Pixel 8, dev-debug)

- **Portrait, wiki rempli** (recherche « pierre »/« moon ») : la feuille monte à **73,8 % de l'écran** (mesure uiautomator : tabs à y=629/2400), ~36 cellules visibles clavier levé, ~23 clavier rentré — contre ~4 rangées avant.
- **Écran court (paysage 411 dp)** : 62 % ≈ 255 dp < plancher 320 dp → **chemin de code strictement identique au 0.29.1 livré** (la condition du gate Sol de la nuit — « jamais moins de place qu'avant » — est structurelle, pas seulement testée).
- **fontScale** : le cap est en dp (insensible au fontScale) ; le chrome (tabs/recherche) grandit indépendamment et la feuille M3 se clampe aux insets. Onglet Standard (~25 builtins) : la grille wrappe, la feuille reste courte — le cap est un max, pas un min.
- Bonus vérifié au passage : la restauration de requête wiki (#824) survit à la ré-ouverture.

Captures du dogfood archivées côté session (df900-portrait-final.png).

## Validation

`detektAll :core:ui:testDebugUnitTest :core:ui:lintDebug` ✔.

part of #900

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YiNthxW8eDCwbXrWjLNPh