### PR TITLE
chore(release): 0.29.2 — batch autonome 13/07

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,19 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.29.2` — `internal` (dev) — 2026-07-13
+
+**Batch autonome de l'après-midi** (5 chantiers, gates croisés Claude Fable 5 ↔ GPT 5.6 Sol : deux fixes codés par Sol et gatés par Claude, trois l'inverse).
+
+### Fixes
+- **#918 — recherche globale** : la rangée d'onglets catégories ne disparaît plus après une bascule de catégorie (HFR n'embarque pas le pivot dans les réponses mono-catégorie ; il est désormais conservé). [codé par Sol]
+- **#545 — édition de ses propres posts** : les profils HFR avec « Affichage des outils » désactivée (affichoutils=0) retrouvent Modifier/Supprimer — l'ownership est reconnu par le pseudo de session quand HFR ne sert pas la toolbar (cause reproduite live ; les gardes MP-à-soi/auto-masquage suivent).
+- **#532 — lignes vides alignées sur le web** : contrat serveur capturé live (HFR compresse : n lignes vides → floor(n/2)+1 visibles, sans plafond) ; l'app sous-rendait ces runs depuis #466. Rendu visible sur les posts multi-paragraphes. [codé par Sol]
+- **#872 (a) — libellé « Contenu BBCode »** : épinglé au-dessus du viewport scrollable des éditeurs plein écran — il ne peut plus être rogné par le scroll d'ouverture, à aucun fontScale (nom accessible conservé via la sémantique du champ).
+
+### Améliorations
+- **#900 (volet 2) — panneau smileys** : la grille se cale sur 62 % de la hauteur d'écran (plancher 320 dp) — la feuille atteint ~3/4 de l'écran (mesuré 73,8 % au dogfood), réponse au retour de CharLee.
+
 ## `0.29.1` — `internal` (dev) — 2026-07-13
 
 **Trio multiquote** (#868/#869/#870, PR #920 — le lot retenu de la nuit, mergé après dogfood émulateur complet des 8 contrats du cadrage, au matin post-reboot).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.29.1"
+        versionName = "0.29.2"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,3 +1,6 @@
-Redface 2 v0.29.1 — dev.
+Redface 2 v0.29.2 — dev.
 
-- Multiquote fixed: the "Quote N" basket survives editor round-trips (no more vanishing FAB or counter reset), and the reply sheet no longer shows ghost quotes from a previous session. The basket only clears on a successful send.
+- Search: category tabs no longer vanish after switching categories.
+- Editing: Edit/Delete come back on your own posts when your HFR profile hides the toolbar.
+- Reading: blank-line spacing now matches the website rendering exactly.
+- Editor: the "Contenu BBCode" label is never truncated anymore, and the smiley panel now uses ~3/4 of the screen.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,3 +1,6 @@
-Redface 2 v0.29.1 — dev.
+Redface 2 v0.29.2 — dev.
 
-- Multiquote réparé : le panier « Citer N » survit aux allers-retours avec l'éditeur (plus de FAB disparu ni de compteur reparti à 1), et la feuille de réponse n'affiche plus de citations fantômes d'une session précédente. Le panier ne se vide qu'à l'envoi réussi.
+- Recherche : les onglets de catégories ne disparaissent plus après un changement de catégorie.
+- Édition : Modifier/Supprimer réapparaissent sur vos propres posts si votre profil HFR masque les outils.
+- Lecture : l'espacement des lignes vides suit désormais exactement le rendu du site web.
+- Éditeur : le libellé « Contenu BBCode » n'est plus tronqué, et le panneau smileys occupe ~3/4 de l'écran.


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Bump `versionName` 0.29.1 → 0.29.2 + entrée CHANGELOG + whatsnew fr/en (version en 1re ligne).

Contenu (mergé sur dev) : #918 onglets recherche (PR #925, Sol) · #545 édition affichoutils=0 (PR #926) · #532 lignes vides parité web (PR #928, Sol) · #900-v2 grille smileys 62 % (PR #930) · #872a libellé épinglé (PR #932). Dispatch `channel=dev --ref dev` après merge (autorisation standing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YiNthxW8eDCwbXrWjLNPh