### PR TITLE
feat(topic): maths de mapping de la loupe #182 (pré-POC)

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoomMath.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoomMath.kt
@@ -60,6 +60,115 @@ internal fun panXRange(scale: Float, widthPx: Float): ClosedFloatingPointRange<F
 }
 
 /**
+ * Vertical translation allowed by #182 for a top-left transform origin. At 1x, or when
+ * [viewportHeightPx] is zero, both endpoints are zero. [scale] must be at least 1x and
+ * [viewportHeightPx] non-negative.
+ */
+internal fun panYRange(
+    scale: Float,
+    viewportHeightPx: Float,
+): ClosedFloatingPointRange<Float> {
+    requireScaleAndHeight(scale, viewportHeightPx)
+    return viewportHeightPx * (MIN_ZOOM_SCALE - scale)..0f
+}
+
+/**
+ * Pure downward distribution for the #182 vertical axis. [panYNew] is in screen pixels;
+ * [listRequestViewportPx] is an unscaled viewport-pixel delta for `dispatchRawDelta`.
+ */
+internal data class VerticalDistribution(
+    val panYNew: Float,
+    val listRequestViewportPx: Float,
+)
+
+/**
+ * First phase of an upward content move: converts a non-negative screen-pixel delta into the
+ * unscaled viewport pixels requested from the list. The split is necessary because the list's
+ * consumed value is only available after the caller performs the `dispatchRawDelta` side effect;
+ * [upwardPanYAfterScroll] keeps the second phase pure and independently testable.
+ */
+internal fun upwardListRequestViewportPx(
+    deltaScreenPx: Float,
+    scale: Float,
+): Float {
+    requireNonNegativeScreenDelta(deltaScreenPx)
+    requireScale(scale)
+    return deltaScreenPx / scale
+}
+
+/**
+ * Second phase of an upward content move. The real list scroll is preferred; only its unconsumed
+ * screen-pixel remainder moves [panYOld] toward the lower bound. [consumedViewportPx] is the
+ * finite value actually returned by the list and is deliberately not clamped here. The output is
+ * clamped at both ends so a momentarily invalid pan is repaired even when the list consumes all.
+ */
+internal fun upwardPanYAfterScroll(
+    deltaScreenPx: Float,
+    consumedViewportPx: Float,
+    panYOld: Float,
+    scale: Float,
+    viewportHeightPx: Float,
+): Float {
+    requireNonNegativeScreenDelta(deltaScreenPx)
+    require(consumedViewportPx.isFinite()) { "consumedViewportPx must be finite" }
+    require(panYOld.isFinite()) { "panYOld must be finite" }
+    val range = panYRange(scale, viewportHeightPx)
+    val unconsumedScreenPx = deltaScreenPx - consumedViewportPx * scale
+    return (panYOld - unconsumedScreenPx).coerceIn(range)
+}
+
+/**
+ * Distributes a negative screen-pixel content delta by unwinding vertical layer translation
+ * before requesting any backward list scroll. Unlike the upward path, this can stay one pure
+ * phase because the list request is fully known before the caller performs its side effect.
+ *
+ * The pan is clamped at both bounds, and its signed contribution is measured from the actual
+ * [panYOld], not from a pre-clamped copy. An input above zero is offset by an extra backward list
+ * request. If a repair from below the lower bound exceeds the requested move, no opposite list
+ * request is emitted and the displacement is best-effort. The list request is in viewport pixels.
+ */
+internal fun downwardDistribution(
+    deltaScreenPx: Float,
+    panYOld: Float,
+    scale: Float,
+    viewportHeightPx: Float,
+): VerticalDistribution {
+    require(deltaScreenPx.isFinite() && deltaScreenPx < 0f) {
+        "deltaScreenPx must be finite and negative"
+    }
+    require(panYOld.isFinite()) { "panYOld must be finite" }
+    val range = panYRange(scale, viewportHeightPx)
+    val downScreenPx = -deltaScreenPx
+    val panYNew = (panYOld + downScreenPx).coerceIn(range)
+    val usedByPanYScreenPx = panYNew - panYOld
+    val remainingScreenPx = downScreenPx - usedByPanYScreenPx
+    val listRequestViewportPx =
+        if (remainingScreenPx > 0f) -remainingScreenPx / scale else 0f
+    return VerticalDistribution(panYNew, listRequestViewportPx)
+}
+
+/**
+ * Screen-space drift of the content point that was under [anchorY] before a scale step. [panYNew]
+ * is the already re-clamped layer translation for [scaleNew]. A positive result means that the
+ * point landed below the anchor and the caller must move content upward by that many screen pixels.
+ */
+internal fun anchoredVerticalDrift(
+    anchorY: Float,
+    panYOld: Float,
+    scaleOld: Float,
+    scaleNew: Float,
+    panYNew: Float,
+): Float {
+    require(anchorY.isFinite()) { "anchorY must be finite" }
+    require(panYOld.isFinite()) { "panYOld must be finite" }
+    requireScale(scaleOld)
+    requireScale(scaleNew)
+    require(panYNew.isFinite()) { "panYNew must be finite" }
+    val viewportY = (anchorY - panYOld) / scaleOld
+    return viewportY * scaleNew + panYNew - anchorY
+}
+
+/**
  * Zoom draw-layer state of the #182 magnifier: a uniform [scale] with a top-left transform origin
  * and a horizontal-only [panX] translation. There is deliberately no vertical translation — the
  * vertical axis is navigated by REAL list scrolling (the lazy list cannot reveal uncomposed items
@@ -151,6 +260,23 @@ private fun rawScaleForDisplayedScale(scale: Float): Float =
     }
 
 private fun minPanX(scale: Float, widthPx: Float): Float = widthPx * (MIN_ZOOM_SCALE - scale)
+
+private fun requireScale(scale: Float) {
+    require(scale.isFinite() && scale >= MIN_ZOOM_SCALE) { "scale must be finite and at least 1" }
+}
+
+private fun requireScaleAndHeight(scale: Float, viewportHeightPx: Float) {
+    requireScale(scale)
+    require(viewportHeightPx.isFinite() && viewportHeightPx >= 0f) {
+        "viewportHeightPx must be finite and non-negative"
+    }
+}
+
+private fun requireNonNegativeScreenDelta(deltaScreenPx: Float) {
+    require(deltaScreenPx.isFinite() && deltaScreenPx >= 0f) {
+        "deltaScreenPx must be finite and non-negative"
+    }
+}
 
 private fun requireScaleAndWidth(scale: Float, widthPx: Float) {
     require(scale.isFinite() && scale >= MIN_ZOOM_SCALE) { "scale must be finite and at least 1" }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoomMath.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoomMath.kt
@@ -1,28 +1,39 @@
 package fr.forumhfr.redface2.feature.topic
 
+import kotlin.math.atanh
+import kotlin.math.tanh
+
 internal const val MIN_ZOOM_SCALE = 1f
 internal const val MAX_ZOOM_SCALE = 2.5f
 internal const val ZOOM_RELEASE_SNAP_THRESHOLD = 1.03f
-internal const val ZOOM_RUBBER_BAND_RESISTANCE = 0.25f
+
+/** Maximum displayed overshoot past [MAX_ZOOM_SCALE] while the fingers keep squeezing. */
+internal const val ZOOM_RUBBER_BAND_RANGE = 0.25f
+
+// atanh(x) diverges at |x| = 1: displayed scales at the saturation asymptote are clamped just
+// inside it so the inversion in pinchStep stays finite.
+private const val RUBBER_BAND_INVERSION_CEILING = 0.999999f
 
 /**
  * Display scale for the global magnifier gesture (#182).
  *
  * The floor is hard: pinching below 1× never shrinks the topic. Up to [MAX_ZOOM_SCALE], the raw
- * gesture scale is preserved. Past that ceiling, a linear rubber band keeps the mapping continuous
- * and strictly monotone while applying [ZOOM_RUBBER_BAND_RESISTANCE] to any excess. The linear form
- * is deliberately invertible: [pinchStep] can recover the logical raw scale before applying the next
- * incremental zoom factor, so an already-resisted scale is not resisted a second time.
+ * gesture scale is preserved. Past that ceiling, a SATURATING tanh rubber band (the PageSwipe
+ * overpull pattern) bounds the displayed scale under `MAX + ZOOM_RUBBER_BAND_RANGE`: an unbounded
+ * band let a hard squeeze keep growing the scale, and the centroid anchoring then kept scrolling
+ * the list — the screen visibly drifted「by itself」at deep zoom (S25 field report, POC iter 1).
+ * tanh is invertible on its range: [pinchStep] recovers the logical raw scale before applying the
+ * next incremental zoom factor, so an already-resisted scale is not resisted a second time.
  *
- * The rubber band is visual gesture feedback, not a persisted bound. [resolveScaleOnRelease] restores
- * the 2.5× ceiling when the fingers lift.
+ * The rubber band is visual gesture feedback, not a persisted bound. [resolveScaleOnRelease]
+ * restores the 2.5× ceiling when the fingers lift.
  */
 internal fun clampScaleDuringPinch(raw: Float): Float {
     require(raw.isFinite()) { "raw must be finite" }
     return when {
         raw <= MIN_ZOOM_SCALE -> MIN_ZOOM_SCALE
         raw <= MAX_ZOOM_SCALE -> raw
-        else -> MAX_ZOOM_SCALE + (raw - MAX_ZOOM_SCALE) * ZOOM_RUBBER_BAND_RESISTANCE
+        else -> MAX_ZOOM_SCALE + ZOOM_RUBBER_BAND_RANGE * tanh(raw - MAX_ZOOM_SCALE)
     }
 }
 
@@ -134,7 +145,9 @@ private fun rawScaleForDisplayedScale(scale: Float): Float =
     if (scale <= MAX_ZOOM_SCALE) {
         scale
     } else {
-        MAX_ZOOM_SCALE + (scale - MAX_ZOOM_SCALE) / ZOOM_RUBBER_BAND_RESISTANCE
+        val saturation = ((scale - MAX_ZOOM_SCALE) / ZOOM_RUBBER_BAND_RANGE)
+            .coerceAtMost(RUBBER_BAND_INVERSION_CEILING)
+        MAX_ZOOM_SCALE + atanh(saturation)
     }
 
 private fun minPanX(scale: Float, widthPx: Float): Float = widthPx * (MIN_ZOOM_SCALE - scale)

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoomMath.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoomMath.kt
@@ -1,0 +1,145 @@
+package fr.forumhfr.redface2.feature.topic
+
+internal const val MIN_ZOOM_SCALE = 1f
+internal const val MAX_ZOOM_SCALE = 2.5f
+internal const val ZOOM_RELEASE_SNAP_THRESHOLD = 1.03f
+internal const val ZOOM_RUBBER_BAND_RESISTANCE = 0.25f
+
+/**
+ * Display scale for the global magnifier gesture (#182).
+ *
+ * The floor is hard: pinching below 1× never shrinks the topic. Up to [MAX_ZOOM_SCALE], the raw
+ * gesture scale is preserved. Past that ceiling, a linear rubber band keeps the mapping continuous
+ * and strictly monotone while applying [ZOOM_RUBBER_BAND_RESISTANCE] to any excess. The linear form
+ * is deliberately invertible: [pinchStep] can recover the logical raw scale before applying the next
+ * incremental zoom factor, so an already-resisted scale is not resisted a second time.
+ *
+ * The rubber band is visual gesture feedback, not a persisted bound. [resolveScaleOnRelease] restores
+ * the 2.5× ceiling when the fingers lift.
+ */
+internal fun clampScaleDuringPinch(raw: Float): Float {
+    require(raw.isFinite()) { "raw must be finite" }
+    return when {
+        raw <= MIN_ZOOM_SCALE -> MIN_ZOOM_SCALE
+        raw <= MAX_ZOOM_SCALE -> raw
+        else -> MAX_ZOOM_SCALE + (raw - MAX_ZOOM_SCALE) * ZOOM_RUBBER_BAND_RESISTANCE
+    }
+}
+
+/**
+ * Settled scale after a #182 magnifier gesture: near-rest values snap to 1× and rubber-band values
+ * return to the hard 2.5× ceiling. Values between those thresholds are preserved.
+ */
+internal fun resolveScaleOnRelease(gestureScale: Float): Float {
+    require(gestureScale.isFinite()) { "gestureScale must be finite" }
+    return when {
+        gestureScale <= ZOOM_RELEASE_SNAP_THRESHOLD -> MIN_ZOOM_SCALE
+        gestureScale > MAX_ZOOM_SCALE -> MAX_ZOOM_SCALE
+        else -> gestureScale
+    }
+}
+
+/**
+ * Horizontal translation allowed by #182 for a top-left transform origin. At 1×, or when
+ * [widthPx] is zero, both endpoints are zero. [scale] must be at least 1× and [widthPx] non-negative.
+ */
+internal fun panXRange(scale: Float, widthPx: Float): ClosedFloatingPointRange<Float> {
+    requireScaleAndWidth(scale, widthPx)
+    return minPanX(scale, widthPx)..0f
+}
+
+/**
+ * Zoom draw-layer state of the #182 magnifier: a uniform [scale] with a top-left transform origin
+ * and a horizontal-only [panX] translation. There is deliberately no vertical translation — the
+ * vertical axis is navigated by REAL list scrolling (the lazy list cannot reveal uncomposed items
+ * through a layer translation).
+ */
+internal data class ZoomTransform(
+    val scale: Float,
+    val panX: Float,
+)
+
+/**
+ * Pure result of one #182 pinch sample. [scaleNew] and [panXNew] are draw-layer values;
+ * [scrollByPx] is an unscaled viewport-pixel delta for `LazyListState.scrollBy`.
+ */
+internal data class PinchStep(
+    val scaleNew: Float,
+    val panXNew: Float,
+    val scrollByPx: Float,
+)
+
+/**
+ * Maps one incremental pinch sample while keeping the content under the centroid anchored (#182).
+ *
+ * X uses the top-left layer mapping `screenX = viewportX * scale + panX`. Recovering
+ * `viewportX = (centroidX - panXOld) / scaleOld` and solving at the new scale gives the corrected
+ * pan. The pan is then clamped to [panXRange]; reaching an edge deliberately makes X anchoring
+ * best-effort.
+ *
+ * Y is real list scrolling, never layer translation. A positive `scrollBy` moves content upward in
+ * unscaled viewport pixels, so `(centroidY / scaleOld - scrollByPx) * scaleNew = centroidY` gives
+ * `scrollByPx = centroidY / scaleOld - centroidY / scaleNew`.
+ *
+ * [current] carries the displayed scale. Above [MAX_ZOOM_SCALE], the linear rubber band is
+ * inverted before applying [zoomFactor]; otherwise incremental samples would re-apply resistance
+ * and a zoom-in could reduce the displayed scale. Inputs must be finite, the current scale at
+ * least 1×, [zoomFactor] positive, and [widthPx] non-negative. Centroids may lie outside the
+ * viewport.
+ */
+internal fun pinchStep(
+    current: ZoomTransform,
+    centroidX: Float,
+    centroidY: Float,
+    zoomFactor: Float,
+    widthPx: Float,
+): PinchStep {
+    val scaleOld = current.scale
+    val panXOld = current.panX
+    requireScaleAndWidth(scaleOld, widthPx)
+    require(panXOld.isFinite()) { "panXOld must be finite" }
+    require(centroidX.isFinite()) { "centroidX must be finite" }
+    require(centroidY.isFinite()) { "centroidY must be finite" }
+    require(zoomFactor.isFinite() && zoomFactor > 0f) { "zoomFactor must be finite and positive" }
+
+    if (zoomFactor == 1f) {
+        val panX = panXOld.coerceIn(minPanX(scaleOld, widthPx), 0f)
+        return PinchStep(scaleOld, panX, scrollByPx = 0f)
+    }
+    val scaleNew = clampScaleDuringPinch(rawScaleForDisplayedScale(scaleOld) * zoomFactor)
+    val viewportX = (centroidX - panXOld) / scaleOld
+    val correctedPanX = centroidX - viewportX * scaleNew
+    val panXNew = correctedPanX.coerceIn(minPanX(scaleNew, widthPx), 0f)
+    val scrollByPx = centroidY / scaleOld - centroidY / scaleNew
+    return PinchStep(scaleNew, panXNew, scrollByPx)
+}
+
+/**
+ * Applies one physical one-finger horizontal delta in the #182 zoomed state, clamped so the scaled
+ * topic never exposes space outside the list width. Positive [deltaX] moves the layer right.
+ */
+internal fun panStep(
+    panXOld: Float,
+    deltaX: Float,
+    scale: Float,
+    widthPx: Float,
+): Float {
+    requireScaleAndWidth(scale, widthPx)
+    require(panXOld.isFinite()) { "panXOld must be finite" }
+    require(deltaX.isFinite()) { "deltaX must be finite" }
+    return (panXOld + deltaX).coerceIn(minPanX(scale, widthPx), 0f)
+}
+
+private fun rawScaleForDisplayedScale(scale: Float): Float =
+    if (scale <= MAX_ZOOM_SCALE) {
+        scale
+    } else {
+        MAX_ZOOM_SCALE + (scale - MAX_ZOOM_SCALE) / ZOOM_RUBBER_BAND_RESISTANCE
+    }
+
+private fun minPanX(scale: Float, widthPx: Float): Float = widthPx * (MIN_ZOOM_SCALE - scale)
+
+private fun requireScaleAndWidth(scale: Float, widthPx: Float) {
+    require(scale.isFinite() && scale >= MIN_ZOOM_SCALE) { "scale must be finite and at least 1" }
+    require(widthPx.isFinite() && widthPx >= 0f) { "widthPx must be finite and non-negative" }
+}

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoomMathTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoomMathTest.kt
@@ -1,0 +1,248 @@
+package fr.forumhfr.redface2.feature.topic
+
+import kotlin.math.abs
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TopicZoomMathTest {
+
+    @Test
+    fun `pinch keeps the content under the centroid fixed on screen`() {
+        val rubberedScale = clampScaleDuringPinch(raw = 3f)
+        val cases = listOf(
+            PinchCase(
+                label = "zoom in from rest",
+                scaleOld = 1f,
+                panXOld = 0f,
+                centroidX = 400f,
+                centroidY = 800f,
+                zoomFactor = 1.5f,
+                widthPx = 1080f,
+            ),
+            PinchCase(
+                label = "zoom in with existing pan",
+                scaleOld = 1.75f,
+                panXOld = -300f,
+                centroidX = 500f,
+                centroidY = 300f,
+                zoomFactor = 1.2f,
+                widthPx = 1000f,
+            ),
+            PinchCase(
+                label = "zoom out with existing pan",
+                scaleOld = 2.2f,
+                panXOld = -600f,
+                centroidX = 400f,
+                centroidY = 950f,
+                zoomFactor = 0.8f,
+                widthPx = 1000f,
+            ),
+            PinchCase(
+                label = "zoom in from rubber band",
+                scaleOld = rubberedScale,
+                panXOld = -500f,
+                centroidX = 400f,
+                centroidY = 700f,
+                zoomFactor = 1.1f,
+                widthPx = 1000f,
+            ),
+            PinchCase(
+                label = "zoom out from rubber band",
+                scaleOld = rubberedScale,
+                panXOld = -500f,
+                centroidX = 400f,
+                centroidY = 700f,
+                zoomFactor = 0.9f,
+                widthPx = 1000f,
+            ),
+        )
+
+        cases.forEach(::assertScreenInvariant)
+    }
+
+    @Test
+    fun `scroll sign follows LazyListState viewport pixels`() {
+        val zoomIn = pinchStep(
+            current = ZoomTransform(scale = 1.5f, panX = -200f),
+            centroidX = 400f,
+            centroidY = 800f,
+            zoomFactor = 1.2f,
+            widthPx = 1000f,
+        )
+        val zoomOut = pinchStep(
+            current = ZoomTransform(scale = 1.8f, panX = -300f),
+            centroidX = 400f,
+            centroidY = 800f,
+            zoomFactor = 0.8f,
+            widthPx = 1000f,
+        )
+
+        assertTrue("zoom-in must request positive scrollBy", zoomIn.scrollByPx > 0f)
+        assertTrue("zoom-out must request negative scrollBy", zoomOut.scrollByPx < 0f)
+    }
+
+    @Test
+    fun `centroid correction clamps pan at both edges as best effort`() {
+        val widthPx = 1000f
+        val rightEdge = pinchStep(
+            current = ZoomTransform(scale = 2f, panX = 0f),
+            centroidX = 400f,
+            centroidY = 600f,
+            zoomFactor = 0.75f,
+            widthPx = widthPx,
+        )
+        val leftEdge = pinchStep(
+            current = ZoomTransform(scale = 2f, panX = panXRange(scale = 2f, widthPx = widthPx).start),
+            centroidX = 600f,
+            centroidY = 600f,
+            zoomFactor = 0.75f,
+            widthPx = widthPx,
+        )
+
+        assertEquals(0f, rightEdge.panXNew, TOLERANCE)
+        assertEquals(panXRange(leftEdge.scaleNew, widthPx).start, leftEdge.panXNew, TOLERANCE)
+
+        // Once an X edge is reached, exposing no blank strip wins over centroid invariance.
+        val rightContentX = 400f / 2f
+        val leftContentX = (600f - panXRange(2f, widthPx).start) / 2f
+        val rightScreenX = rightContentX * rightEdge.scaleNew + rightEdge.panXNew
+        val leftScreenX = leftContentX * leftEdge.scaleNew + leftEdge.panXNew
+        assertTrue(abs(rightScreenX - 400f) > TOLERANCE)
+        assertTrue(abs(leftScreenX - 600f) > TOLERANCE)
+
+        // X clamping is independent from the real-list correction, so Y remains anchored here.
+        assertYInvariant(centroidY = 600f, scaleOld = 2f, step = rightEdge)
+        assertYInvariant(centroidY = 600f, scaleOld = 2f, step = leftEdge)
+    }
+
+    @Test
+    fun `one finger pan and pan range clamp at both bounds`() {
+        val range = panXRange(scale = 2f, widthPx = 500f)
+
+        assertEquals(-500f, range.start, TOLERANCE)
+        assertEquals(0f, range.endInclusive, TOLERANCE)
+        assertEquals(0f, panStep(-250f, deltaX = 400f, scale = 2f, widthPx = 500f), TOLERANCE)
+        assertEquals(-500f, panStep(-250f, deltaX = -400f, scale = 2f, widthPx = 500f), TOLERANCE)
+        assertEquals(-150f, panStep(-250f, deltaX = 100f, scale = 2f, widthPx = 500f), TOLERANCE)
+    }
+
+    @Test
+    fun `pinch scale has a hard floor and a continuous monotone rubber band`() {
+        assertEquals(MIN_ZOOM_SCALE, clampScaleDuringPinch(raw = -2f), TOLERANCE)
+        assertEquals(MIN_ZOOM_SCALE, clampScaleDuringPinch(raw = 0.8f), TOLERANCE)
+        assertEquals(2.25f, clampScaleDuringPinch(raw = 2.25f), TOLERANCE)
+
+        val atJoin = clampScaleDuringPinch(raw = MAX_ZOOM_SCALE)
+        val justPastJoin = clampScaleDuringPinch(raw = MAX_ZOOM_SCALE + 0.0004f)
+        assertTrue(justPastJoin > atJoin)
+        assertEquals(atJoin, justPastJoin, 0.00011f)
+
+        val rawScales = listOf(2.5f, 2.6f, 3f, 4f, 10f)
+        val displayScales = rawScales.map(::clampScaleDuringPinch)
+        displayScales.zipWithNext().forEach { (first, second) ->
+            assertTrue("rubber band must stay monotone: $first then $second", second > first)
+        }
+        assertTrue(clampScaleDuringPinch(raw = 3f) > MAX_ZOOM_SCALE)
+        assertTrue(clampScaleDuringPinch(raw = 3f) < 3f)
+    }
+
+    @Test
+    fun `release snaps near one caps overshoot and preserves settled scales`() {
+        assertEquals(1f, resolveScaleOnRelease(gestureScale = 0.8f), TOLERANCE)
+        assertEquals(1f, resolveScaleOnRelease(gestureScale = 1.03f), TOLERANCE)
+        assertEquals(1.0301f, resolveScaleOnRelease(gestureScale = 1.0301f), TOLERANCE)
+        assertEquals(1.8f, resolveScaleOnRelease(gestureScale = 1.8f), TOLERANCE)
+        assertEquals(2.5f, resolveScaleOnRelease(gestureScale = 2.5f), TOLERANCE)
+        assertEquals(2.5f, resolveScaleOnRelease(gestureScale = 2.8f), TOLERANCE)
+    }
+
+    @Test
+    fun `incremental factors remain directional in the rubber band`() {
+        val scaleOld = clampScaleDuringPinch(raw = 3f)
+        val rubbered = ZoomTransform(scale = scaleOld, panX = -500f)
+        val noOp = pinchStep(rubbered, 400f, 700f, 1f, 1000f)
+        val zoomIn = pinchStep(rubbered, 400f, 700f, 1.01f, 1000f)
+        val zoomOut = pinchStep(rubbered, 400f, 700f, 0.99f, 1000f)
+
+        assertEquals(scaleOld, noOp.scaleNew, 0f)
+        assertEquals(-500f, noOp.panXNew, 0f)
+        assertEquals(0f, noOp.scrollByPx, 0f)
+        assertTrue("rubbered zoom-in must still increase scale", zoomIn.scaleNew > scaleOld)
+        assertTrue("rubbered zoom-out must still decrease scale", zoomOut.scaleNew < scaleOld)
+    }
+
+    @Test
+    fun `floor width zero and top centroid keep their independent degeneracies`() {
+        val floor = pinchStep(
+            current = ZoomTransform(scale = 1f, panX = -100f),
+            centroidX = 400f,
+            centroidY = 600f,
+            zoomFactor = 0.5f,
+            widthPx = 1000f,
+        )
+        assertEquals(1f, floor.scaleNew, TOLERANCE)
+        assertEquals(0f, floor.panXNew, TOLERANCE)
+        assertEquals(0f, floor.scrollByPx, TOLERANCE)
+
+        val zeroWidth = pinchStep(ZoomTransform(1.5f, -100f), 200f, 600f, 1.2f, widthPx = 0f)
+        assertEquals(0f, panXRange(scale = 2f, widthPx = 0f).start, TOLERANCE)
+        assertEquals(0f, zeroWidth.panXNew, TOLERANCE)
+        assertEquals(0f, panStep(-100f, 50f, scale = 2f, widthPx = 0f), TOLERANCE)
+        assertTrue("zero width must not disable scale", zeroWidth.scaleNew > 1.5f)
+        assertTrue("zero width must not disable Y correction", zeroWidth.scrollByPx > 0f)
+
+        val topCentroid = pinchStep(ZoomTransform(1.5f, -100f), 200f, 0f, 1.2f, widthPx = 1000f)
+        assertEquals(0f, topCentroid.scrollByPx, TOLERANCE)
+    }
+
+    @Test
+    fun `invalid non gesture inputs are rejected`() {
+        assertThrows(IllegalArgumentException::class.java) { clampScaleDuringPinch(Float.NaN) }
+        assertThrows(IllegalArgumentException::class.java) { resolveScaleOnRelease(Float.POSITIVE_INFINITY) }
+        assertThrows(IllegalArgumentException::class.java) { panXRange(scale = 0.9f, widthPx = 1000f) }
+        assertThrows(IllegalArgumentException::class.java) { panXRange(scale = 2f, widthPx = -1f) }
+        assertThrows(IllegalArgumentException::class.java) {
+            pinchStep(ZoomTransform(1.5f, 0f), 100f, 100f, zoomFactor = 0f, widthPx = 1000f)
+        }
+    }
+
+    private fun assertScreenInvariant(case: PinchCase) {
+        val contentViewportX = (case.centroidX - case.panXOld) / case.scaleOld
+        val contentViewportY = case.centroidY / case.scaleOld
+        val step = pinchStep(
+            current = ZoomTransform(scale = case.scaleOld, panX = case.panXOld),
+            centroidX = case.centroidX,
+            centroidY = case.centroidY,
+            zoomFactor = case.zoomFactor,
+            widthPx = case.widthPx,
+        )
+
+        val screenXAfter = contentViewportX * step.scaleNew + step.panXNew
+        // Positive scrollBy moves the content up before the draw layer applies its new scale.
+        val screenYAfter = (contentViewportY - step.scrollByPx) * step.scaleNew
+        assertEquals("${case.label} X", case.centroidX, screenXAfter, TOLERANCE)
+        assertEquals("${case.label} Y", case.centroidY, screenYAfter, TOLERANCE)
+    }
+
+    private fun assertYInvariant(centroidY: Float, scaleOld: Float, step: PinchStep) {
+        val contentViewportY = centroidY / scaleOld
+        val screenYAfter = (contentViewportY - step.scrollByPx) * step.scaleNew
+        assertEquals(centroidY, screenYAfter, TOLERANCE)
+    }
+
+    private data class PinchCase(
+        val label: String,
+        val scaleOld: Float,
+        val panXOld: Float,
+        val centroidX: Float,
+        val centroidY: Float,
+        val zoomFactor: Float,
+        val widthPx: Float,
+    )
+
+    private companion object {
+        const val TOLERANCE = 0.01f
+    }
+}

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoomMathTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoomMathTest.kt
@@ -208,6 +208,165 @@ class TopicZoomMathTest {
         }
     }
 
+    @Test
+    fun `vertical range spans the scaled viewport and collapses at one`() {
+        val zoomed = panYRange(scale = 2f, viewportHeightPx = 1000f)
+        val collapsed = panYRange(scale = 1f, viewportHeightPx = 1000f)
+
+        assertEquals(-1000f, zoomed.start, TOLERANCE)
+        assertEquals(0f, zoomed.endInclusive, TOLERANCE)
+        assertEquals(0f, collapsed.start, TOLERANCE)
+        assertEquals(0f, collapsed.endInclusive, TOLERANCE)
+    }
+
+    @Test
+    fun `vertical anchor survives full partial and saturated list scroll`() {
+        val anchorY = 600f
+        val scaleOld = 2f
+        val scaleNew = 2.5f
+        val panYOld = -400f
+        val panYAfterScale = panYOld.coerceIn(panYRange(scaleNew, viewportHeightPx = 1000f))
+        val contentViewportY = (anchorY - panYOld) / scaleOld
+        val driftScreenPx = anchoredVerticalDrift(
+            anchorY = anchorY,
+            panYOld = panYOld,
+            scaleOld = scaleOld,
+            scaleNew = scaleNew,
+            panYNew = panYAfterScale,
+        )
+        val requestViewportPx = upwardListRequestViewportPx(driftScreenPx, scaleNew)
+        val cases = listOf(
+            100f to -400f,
+            60f to -500f,
+            0f to -650f,
+        )
+
+        assertEquals(250f, driftScreenPx, TOLERANCE)
+        assertEquals(100f, requestViewportPx, TOLERANCE)
+        cases.forEach { (consumedViewportPx, expectedPanY) ->
+            val panYNew = upwardPanYAfterScroll(
+                deltaScreenPx = driftScreenPx,
+                consumedViewportPx = consumedViewportPx,
+                panYOld = panYAfterScale,
+                scale = scaleNew,
+                viewportHeightPx = 1000f,
+            )
+            val screenYAfter = (contentViewportY - consumedViewportPx) * scaleNew + panYNew
+
+            assertEquals(expectedPanY, panYNew, TOLERANCE)
+            assertEquals(anchorY, screenYAfter, TOLERANCE)
+        }
+    }
+
+    @Test
+    fun `vertical anchor is best effort when pan and list are both saturated`() {
+        val anchorY = 800f
+        val scaleOld = 2f
+        val scaleNew = 1.5f
+        val panYOld = -1000f
+        val panYAfterScale = panYOld.coerceIn(panYRange(scaleNew, viewportHeightPx = 1000f))
+        val contentViewportY = (anchorY - panYOld) / scaleOld
+        val driftScreenPx = anchoredVerticalDrift(
+            anchorY = anchorY,
+            panYOld = panYOld,
+            scaleOld = scaleOld,
+            scaleNew = scaleNew,
+            panYNew = panYAfterScale,
+        )
+        val panYFinal = upwardPanYAfterScroll(
+            deltaScreenPx = driftScreenPx,
+            consumedViewportPx = 0f,
+            panYOld = panYAfterScale,
+            scale = scaleNew,
+            viewportHeightPx = 1000f,
+        )
+        val screenYAfter = contentViewportY * scaleNew + panYFinal
+
+        assertEquals(50f, driftScreenPx, TOLERANCE)
+        assertEquals(-500f, panYFinal, TOLERANCE)
+        assertEquals(850f, screenYAfter, TOLERANCE)
+        assertTrue(abs(screenYAfter - anchorY) > TOLERANCE)
+    }
+
+    @Test
+    fun `upward remainder uses screen pan only as far as its lower bound`() {
+        val requestViewportPx = upwardListRequestViewportPx(deltaScreenPx = 800f, scale = 2f)
+        val panYNew = upwardPanYAfterScroll(
+            deltaScreenPx = 800f,
+            consumedViewportPx = 100f,
+            panYOld = -700f,
+            scale = 2f,
+            viewportHeightPx = 1000f,
+        )
+
+        assertEquals(400f, requestViewportPx, TOLERANCE)
+        assertEquals(-1000f, panYNew, TOLERANCE)
+    }
+
+    @Test
+    fun `downward movement unwinds pan before requesting backward list scroll`() {
+        val absorbedByPan = downwardDistribution(
+            deltaScreenPx = -400f,
+            panYOld = -600f,
+            scale = 2f,
+            viewportHeightPx = 1000f,
+        )
+        val withListRemainder = downwardDistribution(
+            deltaScreenPx = -800f,
+            panYOld = -600f,
+            scale = 2f,
+            viewportHeightPx = 1000f,
+        )
+
+        assertEquals(-200f, absorbedByPan.panYNew, TOLERANCE)
+        assertEquals(0f, absorbedByPan.listRequestViewportPx, TOLERANCE)
+        assertEquals(0f, withListRemainder.panYNew, TOLERANCE)
+        assertEquals(-100f, withListRemainder.listRequestViewportPx, TOLERANCE)
+    }
+
+    @Test
+    fun `downward movement repairs pan outside both bounds`() {
+        val belowRange = downwardDistribution(
+            deltaScreenPx = -100f,
+            panYOld = -1200f,
+            scale = 2f,
+            viewportHeightPx = 1000f,
+        )
+        val aboveRange = downwardDistribution(
+            deltaScreenPx = -100f,
+            panYOld = 100f,
+            scale = 2f,
+            viewportHeightPx = 1000f,
+        )
+
+        assertEquals(-1000f, belowRange.panYNew, TOLERANCE)
+        assertEquals(0f, belowRange.listRequestViewportPx, TOLERANCE)
+        assertEquals(0f, aboveRange.panYNew, TOLERANCE)
+        assertEquals(-100f, aboveRange.listRequestViewportPx, TOLERANCE)
+    }
+
+    @Test
+    fun `invalid vertical inputs are rejected`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            panYRange(scale = 0.9f, viewportHeightPx = 1000f)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            panYRange(scale = 2f, viewportHeightPx = -1f)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            upwardListRequestViewportPx(deltaScreenPx = -1f, scale = 2f)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            upwardPanYAfterScroll(10f, Float.NaN, 0f, 2f, 1000f)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            downwardDistribution(0f, panYOld = 0f, scale = 2f, viewportHeightPx = 1000f)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            anchoredVerticalDrift(100f, 0f, scaleOld = 0f, scaleNew = 2f, panYNew = 0f)
+        }
+    }
+
     private fun assertScreenInvariant(case: PinchCase) {
         val contentViewportX = (case.centroidX - case.panXOld) / case.scaleOld
         val contentViewportY = case.centroidY / case.scaleOld


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Exigence §2.1-7 du dossier #182 : les formules de coordonnées sont posées et prouvées par tests unitaires purs **avant** tout branchement UI. Socle de la branche POC `poc/182-pinch-loupe` (#935).

- `TopicZoomMath` : plancher dur 1×, plafond 2,5× avec rubber-band linéaire **inversible** (les échantillons incrémentaux ne subissent jamais la résistance deux fois), bornes panX origine haut-gauche, `pinchStep` ancré au centroïde (correction panX + delta `scrollBy` en px viewport non scalés), `panStep` 1 doigt clampé.
- 9 tests d'invariance : le point de contenu sous le centroïde ne bouge pas à l'écran (zoom in/out, depuis le repos, avec pan, depuis le rubber-band) ; ancrage X best-effort documenté aux deux bords clampés ; signe du scroll ; continuité/monotonie au raccord ; snap/cap au relâcher ; entrées dégénérées.

**Duo** : code écrit par GPT 5.6 Sol (session workspace-write, notes archivées `redface2-work/logs/SOL-NOTES-182-mapping.md`) ; review + refactor `ZoomTransform` (detekt LongParameterList) par Claude. Validation canonique ciblée : detektAll + `:feature:topic:testDebugUnitTest` (9/9) + lintDebug — BUILD SUCCESSFUL.

**Draft volontaire** : merge conditionné au POC A GO (#935) — si le POC invalide une formule, la branche est corrigée avant d'entrer sur dev. Sol a relevé une ambiguïté de signe dans la prose du draft (§2.1-7 « contenu descend ») : la formule testée fait foi, clarification prose à la spec d'implémentation.

part of #935

- [x] Review croisée : Sol auteur / Claude reviewer-validateur

🤖 Generated with [Claude Code](https://claude.com/claude-code)