### PR TITLE
fix(topic): annulation multi-touch native de topicPageSwipe (#936)

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipe.kt
@@ -8,12 +8,16 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.awaitHorizontalTouchSlopOrCancellation
-import androidx.compose.foundation.gestures.horizontalDrag
 import androidx.compose.runtime.MutableFloatState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.AwaitPointerEventScope
+import androidx.compose.ui.input.pointer.PointerId
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.changedToDownIgnoreConsumed
+import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.input.pointer.util.VelocityTracker
@@ -186,11 +190,13 @@ internal fun Modifier.topicPageSwipe(
                 var armed = false
                 velocityTracker.addPosition(drag.uptimeMillis, drag.position)
                 dragOffset.floatValue = followOffsetFor(totalDx, commitDistancePx, currentPage, totalPages())
-                // `horizontalDrag` returns false when the drag is CANCELLED — e.g. a descendant
-                // horizontal scroller (a wide `[fixed]` code block, the page grid) takes the pointer
-                // over after we crossed slop. Honour it: a taken-over gesture must NOT navigate.
-                val completed = horizontalDrag(drag.id) { change ->
+                // #936 — [trackHorizontalDrag] replaces `horizontalDrag(drag.id)`: the helper
+                // never hands the full event back, so a SECOND pointer landing mid-drag stayed
+                // invisible until something else consumed our pointer. Any outcome but COMPLETED
+                // cancels into the same spring-back, before any velocity/commit computation.
+                val outcome = trackHorizontalDrag(drag.id) { change ->
                     totalDx += change.positionChange().x
+                    // VelocityTracker feed unchanged: the PRIMARY pointer only.
                     velocityTracker.addPosition(change.uptimeMillis, change.position)
                     val offset = followOffsetFor(totalDx, commitDistancePx, currentPage, totalPages())
                     dragOffset.floatValue = offset // synchronous, no coroutine, no allocation
@@ -199,7 +205,7 @@ internal fun Modifier.topicPageSwipe(
                     armed = nowArmed
                     change.consume()
                 }
-                if (!completed) {
+                if (outcome != DragOutcome.COMPLETED) {
                     releaseJob = springBackTo(animationScope, release, dragOffset)
                     return@awaitEachGesture
                 }
@@ -251,6 +257,49 @@ internal class TopicSwipeHandlers(
     val leftGestureInsetPx: () -> Int,
     val rightGestureInsetPx: () -> Int,
 )
+
+/** How a tracked drag ended — anything but [COMPLETED] must cancel into the spring-back. */
+private enum class DragOutcome { MULTI_TOUCH, TAKEN_OVER, COMPLETED }
+
+/**
+ * #936 — the drag event loop of [topicPageSwipe]. Contract: any secondary contact during an
+ * uncommitted drag cancels the swipe — even past the commit distance (armed ≠ committed), with NO
+ * pointer transfer. The multi-touch check reads the raw pointer TOPOLOGY (a down on another id,
+ * consumption ignored) BEFORE looking at `isConsumed`, so the outcome never depends on what
+ * another detector (e.g. the #182 magnifier, Initial pass) did with the event; the cancelling
+ * event is deliberately NOT consumed (the second finger belongs to whoever claims it next).
+ * Scope pinned on the issue: post-slop only — before slop no swipe exists yet (no translation,
+ * no arming), the natural slop race decides.
+ */
+private suspend fun AwaitPointerEventScope.trackHorizontalDrag(
+    dragId: PointerId,
+    onMove: (PointerInputChange) -> Unit,
+): DragOutcome {
+    var outcome: DragOutcome? = null
+    while (outcome == null) {
+        val event = awaitPointerEvent()
+        val change = event.changes.firstOrNull { it.id == dragId }
+        when {
+            // Topology FIRST: catches the secondary down even when the SAME event also carries
+            // the primary up (no transfer — an armed swipe is not committed).
+            event.changes.any { it.id != dragId && it.changedToDownIgnoreConsumed() } ->
+                outcome = DragOutcome.MULTI_TOUCH
+            // The primary pointer vanished from the stream without an up: cancel, never hang
+            // (gate Sol r1 — `Unit` here left the loop suspended forever).
+            change == null -> outcome = DragOutcome.TAKEN_OVER
+            // Up BEFORE isConsumed, like the former horizontalDrag: a consumed up still ENDS the
+            // drag normally (gate Sol r1 — it was misclassified as a takeover).
+            change.changedToUpIgnoreConsumed() -> outcome = DragOutcome.COMPLETED
+            // Taken over by a descendant horizontal scroller (a wide `[fixed]` code block, the
+            // page grid) — same cancellation semantics as the former horizontalDrag.
+            change.isConsumed -> outcome = DragOutcome.TAKEN_OVER
+            // HORIZONTAL movement only (gate Sol r1): `positionChanged()` also accepted purely
+            // vertical deltas, stealing the list scroll and skewing the horizontal velocity.
+            change.positionChange().x != 0f -> onMove(change)
+        }
+    }
+    return outcome
+}
 
 /** Spring the page back to rest (cancel / no-commit), streaming the animation into [dragOffset]. */
 private fun springBackTo(

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipeMultiTouchTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicSwipeMultiTouchTest.kt
@@ -1,0 +1,205 @@
+package fr.forumhfr.redface2.feature.topic
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.unit.dp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * #936 — multi-touch hardening of [topicPageSwipe], the first TESTED slice of the #182 magnifier:
+ * a second pointer landing during an UNCOMMITTED drag must cancel the swipe into the existing
+ * spring-back (no navigation, no residual translation) — even past the commit distance (armed is
+ * not committed), reading the raw pointer topology BEFORE consumption so the outcome never depends
+ * on another detector's pass order. These tests run WITHOUT the magnifier in the tree on purpose:
+ * with it, its Initial-pass consumption alone would cancel the drag and the test would stay green
+ * without proving anything about the swipe's own defense.
+ *
+ * Geometry: box 360dp wide at xxhdpi. Commit distance = max(width×0.20, 72dp) = 72dp+; total
+ * drags of 600px (~200dp) are safely past both slop and the commit distance.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h780dp-xxhdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class TopicSwipeMultiTouchTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private fun setSwipeContent(
+        dragOffset: androidx.compose.runtime.MutableFloatState,
+        onOpenPage: (Int) -> Unit,
+    ) {
+        compose.setContent {
+            Box(
+                Modifier
+                    .size(360.dp, 600.dp)
+                    .testTag("page")
+                    .topicPageSwipe(
+                        currentPage = 5,
+                        totalPages = { 10 },
+                        dragOffset = dragOffset,
+                        handlers = TopicSwipeHandlers(
+                            haptics = LocalHapticFeedback.current,
+                            onOpenPage = onOpenPage,
+                            enabled = { true },
+                            leftGestureInsetPx = { 0 },
+                            rightGestureInsetPx = { 0 },
+                        ),
+                    ),
+            )
+        }
+    }
+
+    @Test
+    fun `a second pointer during an uncommitted drag cancels without navigating`() {
+        var opened: Int? = null
+        val dragOffset = mutableFloatStateOf(0f)
+        setSwipeContent(dragOffset) { opened = it }
+
+        compose.onNodeWithTag("page").performTouchInput {
+            down(0, center)
+            // Past slop AND past the commit distance: the swipe is ARMED — still cancellable.
+            repeat(10) { moveBy(0, Offset(-60f, 0f)) }
+        }
+        // Post-slop PROOF (gate Sol): the drag must be visibly engaged BEFORE the second finger,
+        // otherwise this test could pass without any swipe ever existing.
+        compose.runOnIdle {
+            assertTrue(
+                "the drag must be engaged before the cancellation is tested",
+                dragOffset.floatValue < -100f,
+            )
+        }
+        compose.onNodeWithTag("page").performTouchInput {
+            down(1, center + Offset(0f, 150f))
+            up(0)
+            up(1)
+        }
+        compose.waitForIdle()
+
+        assertNull("a cancelled swipe must never navigate", opened)
+        assertEquals("spring-back must return the page to rest", 0f, dragOffset.floatValue, 0.5f)
+    }
+
+    @Test
+    fun `the primary up racing the secondary down still cancels`() {
+        var opened: Int? = null
+        val dragOffset = mutableFloatStateOf(0f)
+        setSwipeContent(dragOffset) { opened = it }
+
+        compose.onNodeWithTag("page").performTouchInput {
+            down(0, center)
+            repeat(10) { moveBy(0, Offset(-60f, 0f)) }
+            // Adjacent events with no move in between — the closest the test API gets to the
+            // same-frame race. Structural guarantee: the topology branch runs FIRST, so even a
+            // single event carrying both changes resolves to MULTI_TOUCH (armed ≠ committed).
+            down(1, center + Offset(0f, 150f))
+            up(0)
+            up(1)
+        }
+        compose.waitForIdle()
+
+        assertNull("no transfer: the armed swipe must cancel, not commit", opened)
+        assertEquals(0f, dragOffset.floatValue, 0.5f)
+    }
+
+    @Test
+    fun `vertical movement past slop does not feed the swipe`() {
+        var opened: Int? = null
+        val dragOffset = mutableFloatStateOf(0f)
+        setSwipeContent(dragOffset) { opened = it }
+
+        compose.onNodeWithTag("page").performTouchInput {
+            down(0, center)
+            repeat(3) { moveBy(0, Offset(-30f, 0f)) } // past slop, under the commit distance
+        }
+        val engaged = dragOffset.floatValue
+        compose.onNodeWithTag("page").performTouchInput {
+            // Purely vertical deltas: the former horizontalDrag ignored them; the hand-rolled
+            // loop must too (gate Sol: positionChanged() accepted them, stealing the scroll).
+            repeat(5) { moveBy(0, Offset(0f, 80f)) }
+        }
+        compose.runOnIdle {
+            assertEquals(
+                "vertical deltas must not move the swipe offset",
+                engaged,
+                dragOffset.floatValue,
+                0.5f,
+            )
+        }
+        compose.onNodeWithTag("page").performTouchInput { up(0) }
+        compose.waitForIdle()
+        assertNull("under the commit distance, release must not navigate", opened)
+    }
+
+    @Test
+    fun `a committed swipe still navigates when a pointer lands during the slide-out`() {
+        var opened: Int? = null
+        val dragOffset = mutableFloatStateOf(0f)
+        setSwipeContent(dragOffset) { opened = it }
+
+        compose.onNodeWithTag("page").performTouchInput {
+            down(0, center)
+            repeat(10) { moveBy(0, Offset(-60f, 0f)) }
+            up(0) // commit: the slide-out starts, then onOpenPage fires
+        }
+        compose.onNodeWithTag("page").performTouchInput {
+            // Lands inside the slide-out window: the committed latch must ignore it.
+            down(1, center)
+            up(1)
+        }
+        compose.waitForIdle()
+
+        assertEquals("the committed navigation must fire exactly once", 6, opened)
+    }
+
+    @Test
+    fun `a single-finger commit still navigates`() {
+        var opened: Int? = null
+        val dragOffset = mutableFloatStateOf(0f)
+        setSwipeContent(dragOffset) { opened = it }
+
+        compose.onNodeWithTag("page").performTouchInput {
+            down(0, center)
+            repeat(10) { moveBy(0, Offset(-60f, 0f)) }
+            up(0)
+        }
+        compose.waitForIdle()
+
+        assertEquals("regression: the plain swipe must keep navigating", 6, opened)
+    }
+
+    @Test
+    fun `a second pointer before slop leaves everything at rest`() {
+        var opened: Int? = null
+        val dragOffset = mutableFloatStateOf(0f)
+        setSwipeContent(dragOffset) { opened = it }
+
+        compose.onNodeWithTag("page").performTouchInput {
+            down(0, center)
+            moveBy(0, Offset(-4f, 0f)) // under slop: no swipe exists yet (#936 scope boundary)
+            down(1, center + Offset(0f, 150f))
+            up(0)
+            up(1)
+        }
+        compose.waitForIdle()
+
+        assertNull(opened)
+        assertEquals(0f, dragOffset.floatValue, 0.5f)
+    }
+}


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Étape 2 du chantier #182 — la « première tranche testée » de l'option A : `topicPageSwipe` se défend seul contre le multi-touch (un 2e contact pendant un drag non commité = annulation vers le spring-back existant, topologie lue AVANT la consommation, aucun transfert de pointeur, armé ≠ commité). Il ne dépend plus de la consommation Initial-pass du magnifier (qui reste en défense en profondeur jusqu'à #937).

**Duo** : cadrage Sol AVANT implémentation (machine d'états, pas de flag partagé — commenté sur #936) → implémentation Claude → **gate Sol r1 NO-GO** (3 divergences sémantiques vs `horizontalDrag` : deltas verticaux volés, up-consommé mal classé, pointeur disparu = suspension) → fixes appliqués à la prescription → **gate r2 GO**. Réserves non bloquantes notées (compteur d'appels exact, preuve d'animation en cours) pour un durcissement ultérieur.

6 tests Compose JVM **sans le magnifier dans l'arbre** (sinon la famine d'événements les ferait passer à tort). Validation : detektAll + suite complète du module + lintDebug — BUILD SUCCESSFUL.

**Draft volontaire** : merge après le GO formel du POC #935 (ordre du plan). part of #182

- [x] Cadrage + gate croisé GPT 5.6 Sol (r1 NO-GO → r2 GO, logs archivés)

🤖 Generated with [Claude Code](https://claude.com/claude-code)