### PR TITLE
feat(topic): loupe globale de lecture — pinch-to-zoom production (#937)

### DIFF
--- a/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostListScaffold.kt
+++ b/core/ui/src/main/kotlin/fr/forumhfr/redface2/core/ui/post/PostListScaffold.kt
@@ -42,6 +42,9 @@ fun PostListScaffold(
     modifier: Modifier = Modifier,
     listModifier: Modifier = Modifier,
     showScrollbar: Boolean = true,
+    // #182 — the topic magnifier suspends native list scrolling while zoomed (the vertical axis is
+    // then driven programmatically via dispatchRawDelta). Default keeps both consumers unchanged.
+    userScrollEnabled: Boolean = true,
     content: LazyListScope.() -> Unit,
 ) {
     Box(modifier = modifier.fillMaxSize()) {
@@ -52,6 +55,7 @@ fun PostListScaffold(
                 .then(listModifier),
             contentPadding = contentPadding,
             verticalArrangement = verticalArrangement,
+            userScrollEnabled = userScrollEnabled,
             content = content,
         )
         if (showScrollbar) {

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -93,6 +93,7 @@ import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
@@ -1252,9 +1253,13 @@ internal fun TopicContent(
                                 modifier = Modifier
                                     .align(Alignment.TopEnd)
                                     .padding(12.dp)
-                                    // #937 — a11y : 48 dp minimum touch target + named action.
+                                    // #937 — a11y : 48 dp minimum touch target, named action,
+                                    // explicit button role (validation 5.5).
                                     .sizeIn(minWidth = 48.dp, minHeight = 48.dp)
-                                    .semantics { contentDescription = zoomResetDescription },
+                                    .semantics {
+                                        contentDescription = zoomResetDescription
+                                        role = Role.Button
+                                    },
                             ) {
                                 Box(
                                     contentAlignment = Alignment.Center,

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1124,12 +1124,14 @@ internal fun TopicContent(
                 }
 
                 is TopicUiState.Mode.Loaded -> {
-                    // POC #182 (#935) — magnifier state hoisted above the pull-to-refresh wrapper:
+                    // #182 (#937) — magnifier state hoisted above the pull-to-refresh wrapper:
                     // the PTR suspension, the selection gate (LocalTopicZoomed) and the reset chip
                     // read it here; the gesture and the draw layer consume it in TopicLoadedContent.
                     val zoomAnimationScope = rememberCoroutineScope()
                     val zoomState = rememberTopicZoomState(
-                        pageKey = mode.topic.page,
+                        // Full route identity (§2.1) — two topics on the same page number must
+                        // never share a zoom ; a page change of the same topic resets too.
+                        pageKey = Triple(state.request.cat, state.request.post, mode.topic.page),
                         animationScope = zoomAnimationScope,
                     )
                     // derivedStateOf: the composition only recomposes on the 1× ↔ zoomed TRANSITION,
@@ -1230,8 +1232,9 @@ internal fun TopicContent(
                             modifier = Modifier.align(Alignment.TopCenter),
                         )
                         if (isZoomed) {
-                            // POC #182 — discreet, always-visible reset affordance while zoomed
+                            // #182 — discreet, always-visible reset affordance while zoomed
                             // (contract RESET). Chrome: stays OUTSIDE the zoomed layer.
+                            val zoomResetDescription = stringResource(R.string.topic_zoom_reset)
                             Surface(
                                 onClick = {
                                     // Anchored on the viewport centre: the content the reader is
@@ -1248,13 +1251,20 @@ internal fun TopicContent(
                                 shadowElevation = 3.dp,
                                 modifier = Modifier
                                     .align(Alignment.TopEnd)
-                                    .padding(12.dp),
+                                    .padding(12.dp)
+                                    // #937 — a11y : 48 dp minimum touch target + named action.
+                                    .sizeIn(minWidth = 48.dp, minHeight = 48.dp)
+                                    .semantics { contentDescription = zoomResetDescription },
                             ) {
-                                Text(
-                                    text = "1×",
-                                    style = MaterialTheme.typography.labelLarge,
-                                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
-                                )
+                                Box(
+                                    contentAlignment = Alignment.Center,
+                                    modifier = Modifier.sizeIn(minWidth = 48.dp, minHeight = 48.dp),
+                                ) {
+                                    Text(
+                                        text = stringResource(R.string.topic_zoom_reset_chip),
+                                        style = MaterialTheme.typography.labelLarge,
+                                    )
+                                }
                             }
                         }
                     }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -56,7 +56,9 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.minimumInteractiveComponentSize
-import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
+import androidx.compose.material3.pulltorefresh.pullToRefresh
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
@@ -64,8 +66,10 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -75,6 +79,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -1118,16 +1124,35 @@ internal fun TopicContent(
                 }
 
                 is TopicUiState.Mode.Loaded -> {
-                    // #335 — pull-to-refresh only wraps the loaded content (Loading/Error don't need
-                    // it). PullToRefreshBox layers a vertical nested-scroll connection on top of the
-                    // top-bar enterAlways behaviour (#338) and the horizontal page swipe (#282); the
-                    // pull only engages on overscroll at the top of the list, so the read position is
-                    // preserved on refresh (the ViewModel emits no scroll effect).
-                    PullToRefreshBox(
-                        isRefreshing = state.isRefreshing,
-                        // #813 — user refresh also clears + re-probes failed media measurements.
-                        onRefresh = refreshWithMediaRetry,
-                        modifier = Modifier.fillMaxSize(),
+                    // POC #182 (#935) — magnifier state hoisted above the pull-to-refresh wrapper:
+                    // the PTR suspension, the selection gate (LocalTopicZoomed) and the reset chip
+                    // read it here; the gesture and the draw layer consume it in TopicLoadedContent.
+                    val zoomAnimationScope = rememberCoroutineScope()
+                    val zoomState = rememberTopicZoomState(
+                        pageKey = mode.topic.page,
+                        animationScope = zoomAnimationScope,
+                    )
+                    // derivedStateOf: the composition only recomposes on the 1× ↔ zoomed TRANSITION,
+                    // never per pinch frame (scale/panX are read in the draw phase only).
+                    val isZoomed by remember(zoomState) { derivedStateOf { zoomState.zoomed } }
+                    // #335 — pull-to-refresh only wraps the loaded content; the pull only engages on
+                    // overscroll at the top of the list, so the read position is preserved on refresh.
+                    // POC #182 : PullToRefreshBox (m3 1.4.0) does not expose `enabled`, so the wrapper
+                    // becomes the low-level Modifier.pullToRefresh + the default Indicator — the pull
+                    // gesture is fully suspended while zoomed (a gate in onRefresh would be too late:
+                    // the gesture would still be consumed and the indicator armed).
+                    val pullToRefreshState = rememberPullToRefreshState()
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .pullToRefresh(
+                                isRefreshing = state.isRefreshing,
+                                state = pullToRefreshState,
+                                enabled = !isZoomed,
+                                // #813 — user refresh also clears + re-probes failed media
+                                // measurements.
+                                onRefresh = refreshWithMediaRetry,
+                            ),
                     ) {
                         // #300/#351 — the intra-page scrollbar now rides inside PostListScaffold
                         // (overlaying the list's right edge, outside the scrolled element), so the
@@ -1138,11 +1163,16 @@ internal fun TopicContent(
                         // is provided to the post renderers so QuoteBlock masks a citation OF a
                         // blocked author. Scoped to the reading list only — the quick-reply sheet
                         // and editor previews (outside this provider) keep the empty default.
-                        CompositionLocalProvider(LocalBlockedQuoteAuthors provides mode.blockedQuoteAuthors) {
+                        CompositionLocalProvider(
+                            LocalBlockedQuoteAuthors provides mode.blockedQuoteAuthors,
+                            // POC #182 — suspends text selection in the post cards while zoomed.
+                            LocalTopicZoomed provides isZoomed,
+                        ) {
                             TopicLoadedContent(
                                 state = state,
                                 topic = mode.topic,
                                 hiddenNumreponses = mode.hiddenNumreponses,
+                                zoomState = zoomState,
                                 // #604 lot 2 / #806 — « Citer » opens the quick-reply sheet with the
                                 // card pre-armed (1-citation session), unless the preset routes any
                                 // citation to the full-screen editor (decision at tap time). #843 —
@@ -1193,6 +1223,39 @@ internal fun TopicContent(
                                 // #813 — explicit-refresh retry for ghost inline images.
                                 mediaRefreshGeneration = mediaRefreshGeneration,
                             )
+                        }
+                        PullToRefreshDefaults.Indicator(
+                            state = pullToRefreshState,
+                            isRefreshing = state.isRefreshing,
+                            modifier = Modifier.align(Alignment.TopCenter),
+                        )
+                        if (isZoomed) {
+                            // POC #182 — discreet, always-visible reset affordance while zoomed
+                            // (contract RESET). Chrome: stays OUTSIDE the zoomed layer.
+                            Surface(
+                                onClick = {
+                                    // Anchored on the viewport centre: the content the reader is
+                                    // looking at stays put while the scale animates back to 1×.
+                                    zoomState.settleAnchoredTo(
+                                        targetScale = 1f,
+                                        anchorX = zoomState.viewportWidthPx / 2f,
+                                        anchorY = zoomState.viewportHeightPx / 2f,
+                                        listState = listState,
+                                    )
+                                },
+                                shape = MaterialTheme.shapes.large,
+                                color = MaterialTheme.colorScheme.secondaryContainer,
+                                shadowElevation = 3.dp,
+                                modifier = Modifier
+                                    .align(Alignment.TopEnd)
+                                    .padding(12.dp),
+                            ) {
+                                Text(
+                                    text = "1×",
+                                    style = MaterialTheme.typography.labelLarge,
+                                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                                )
+                            }
                         }
                     }
                 }
@@ -1671,6 +1734,9 @@ private fun TopicLoadedContent(
     /** #879 — filtered search : « résultats suivants » footer tap. */
     onSearchNextResults: () -> Unit = {},
     listState: LazyListState,
+    // POC #182 (#935) — magnifier state: the gesture + draw layer attach to the list here, and
+    // swipe/double-tap/list-scroll are suspended while zoomed.
+    zoomState: TopicZoomState,
     // #291 — selection state + toggle for the post menu's multi-quote entry.
     multiQuoteSelection: List<Int> = emptyList(),
     onToggleMultiQuote: (preview: QuotedPostPreview) -> Unit = {},
@@ -1764,7 +1830,11 @@ private fun TopicLoadedContent(
     // interrupting the transition → frozen screen. The lambda reads `lifecycle.currentState` live, so
     // the gesture (whose pointerInput does not re-key on this) always sees the current state.
     val entryLifecycle = LocalLifecycleOwner.current.lifecycle
-    val swipeEnabled: () -> Boolean = { entryLifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED) }
+    // POC #182 — the page swipe (and its edge hint) are suspended while zoomed. Gesture-time read
+    // through the lambda: no recomposition per pinch frame.
+    val swipeEnabled: () -> Boolean = {
+        entryLifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED) && !zoomState.zoomed
+    }
     // #752 — system-gesture band widths for the swipe's start dead-zone, resolved here (composable)
     // and handed as ALWAYS-FRESH lambdas (rememberUpdatedState) so the currentPage-keyed
     // pointerInput sees rotation/split-screen changes ; px conversion happens per gesture.
@@ -1783,8 +1853,13 @@ private fun TopicLoadedContent(
     // (#300/#351). The swipe machinery stays feature-owned and is threaded through `listModifier`,
     // applied to the LazyColumn itself (so the list follows the finger and the scrollbar overlay stays
     // fixed); the contentPadding / verticalArrangement / scrollbar gate are passed unchanged.
+    // POC #182 — native list scrolling is suspended while zoomed: the vertical axis is driven by
+    // the magnifier's controlled dispatchRawDelta (screen deltas divided by scale — 1:1 under the
+    // finger). derivedStateOf: recomposes on the 1× ↔ zoomed transition only.
+    val zoomSuspendsScroll by remember(zoomState) { derivedStateOf { zoomState.zoomed } }
     PostListScaffold(
         listState = listState,
+        userScrollEnabled = !zoomSuspendsScroll,
         // #283 — extra bottom padding so the last post's right-aligned actions clear the floating
         // bottom-action cluster (the Scaffold FAB slot floats over the content). Harmless extra
         // breathing room when the cluster is absent (anon + single page).
@@ -1795,6 +1870,12 @@ private fun TopicLoadedContent(
         // a denser feed, cf. the #287 density feedback).
         verticalArrangement = Arrangement.spacedBy(8.dp),
         listModifier = Modifier
+            // POC #182 (#935) — the magnifier gesture listens FIRST (Initial pass) so that, once
+            // pinching, consuming the moves starves the sibling swipe / child scrollers below. It
+            // must also sit BEFORE the zoom graphicsLayer at the end of this chain: centroids are
+            // read in the untransformed local space that TopicZoomMath models (same coordinate
+            // rule as topicPageSwipe).
+            .topicMagnifier(zoomState, listState)
             // #285 — system-bar insets (status + navigation) are now consumed by the Scaffold/TopAppBar
             // in TopicContent and applied via the content Surface's padding(innerPadding); the list no
             // longer adds statusBarsPadding()/navigationBarsPadding() here to avoid double-insetting.
@@ -1844,10 +1925,28 @@ private fun TopicLoadedContent(
             .pointerInput(Unit) {
                 detectTapGestures(
                     onDoubleTap = {
-                        haptics.performHapticFeedback(HapticFeedbackType.Confirm)
-                        onDoubleTapRefresh()
+                        // POC #182 — double-tap refresh is suspended while zoomed (contract ZOOMÉ);
+                        // taps are not consumed by the magnifier, so the gate lives here.
+                        if (!zoomState.zoomed) {
+                            haptics.performHapticFeedback(HapticFeedbackType.Confirm)
+                            onDoubleTapRefresh()
+                        }
                     },
                 )
+            }
+            // POC #182 — the zoom draw layer, LAST in the chain (innermost): the magnifier and the
+            // swipe read their pointers in untransformed space, and the swipe's own translation
+            // layer (identity while zoomed — the swipe is suspended) composes OUTSIDE this scale.
+            // Top-left origin per the contract; scale/panX are frame-state reads (no recomposition).
+            .graphicsLayer {
+                val zoomScale = zoomState.scale.floatValue
+                scaleX = zoomScale
+                scaleY = zoomScale
+                translationX = zoomState.panX.floatValue
+                // Bounded complement of the real scroll at the bottom edge (contract amendment,
+                // POC iter 1) — never exposes uncomposed content, see TopicZoomState.panY.
+                translationY = zoomState.panY.floatValue
+                transformOrigin = TransformOrigin(0f, 0f)
             },
     ) {
         item {
@@ -2676,7 +2775,9 @@ internal fun TopicPostCard(
                 CompositionLocalProvider(LocalPostImageActions provides imageActions) {
                     PostRenderer(
                         content = post.content,
-                        selectable = true,
+                        // POC #182 — selection is suspended while the magnifier is engaged (>1×);
+                        // topic posts are selectable at rest (#281).
+                        selectable = !LocalTopicZoomed.current,
                         onGoToCitedPost = onGoToCitedPost,
                         mediaRefreshGeneration = mediaRefreshGeneration,
                     )

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1940,8 +1940,10 @@ private fun TopicLoadedContent(
             .pointerInput(Unit) {
                 detectTapGestures(
                     onDoubleTap = {
-                        // POC #182 — double-tap refresh is suspended while zoomed (contract ZOOMÉ);
-                        // taps are not consumed by the magnifier, so the gate lives here.
+                        // #182 — double-tap refresh is suspended while zoomed (contract ZOOMÉ).
+                        // The magnifier already consumes the down on its Initial pass while
+                        // zoomed (replied mode), so this guard is DEFENSE IN DEPTH — it keeps
+                        // the suspension correct even if the modifier stacking ever changes.
                         if (!zoomState.zoomed) {
                             haptics.performHapticFeedback(HapticFeedbackType.Confirm)
                             onDoubleTapRefresh()

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoom.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoom.kt
@@ -81,11 +81,25 @@ internal class TopicZoomState(private val animationScope: CoroutineScope) {
     private var stopFlingJob: Job? = null
     private var pendingDeltaScreenPx = 0f
 
+    /**
+     * True while a magnifier gesture owns the transform (review finding) : the reset chip sits
+     * OUTSIDE the gesture area, so a third finger can tap it mid-pinch — without this guard its
+     * settle and the live gesture would both write scale/pan and dispatch scroll deltas.
+     */
+    var gestureEngaged = false
+        private set
+
     /** Called once per gesture, when the magnifier takes ownership (2nd pointer or zoomed pan). */
     fun engage(listState: LazyListState) {
         releaseJob?.cancel()
         pendingDeltaScreenPx = 0f
+        gestureEngaged = true
         stopFlingJob = animationScope.launch { listState.stopScroll() }
+    }
+
+    /** Called when the gesture releases its last pointer — the settle may then take over. */
+    fun releaseGesture() {
+        gestureEngaged = false
     }
 
     /**
@@ -147,22 +161,20 @@ internal class TopicZoomState(private val animationScope: CoroutineScope) {
     }
 
     private fun applyContentDelta(deltaScreenPx: Float, listState: LazyListState) {
+        // Delegates to the PURE TopicZoomMath vertical distribution (review finding : the tested
+        // functions must be the ones the gesture executes — no hand-inlined twin).
         val s = scale.floatValue
-        val minPanY = viewportHeightPx * (1f - s)
         if (deltaScreenPx >= 0f) {
-            val consumed = listState.dispatchRawDelta(deltaScreenPx / s)
-            val rest = deltaScreenPx - consumed * s
-            panY.floatValue = (panY.floatValue - rest).coerceIn(minPanY, 0f)
+            val consumed = listState.dispatchRawDelta(upwardListRequestViewportPx(deltaScreenPx, s))
+            panY.floatValue =
+                upwardPanYAfterScroll(deltaScreenPx, consumed, panY.floatValue, s, viewportHeightPx)
         } else {
-            val down = -deltaScreenPx
-            // Both bounds on the unwind (gate Sol) : equivalent under the invariant, robust if the
-            // state ever lands momentarily out of range (e.g. a reclamp raced a frame).
-            val oldPanY = panY.floatValue
-            val newPanY = (oldPanY + down).coerceIn(minPanY, 0f)
-            val usedByPanY = newPanY - oldPanY
-            panY.floatValue = newPanY
-            val remaining = down - usedByPanY
-            if (remaining > 0f) listState.dispatchRawDelta(-remaining / s)
+            val distribution =
+                downwardDistribution(deltaScreenPx, panY.floatValue, s, viewportHeightPx)
+            panY.floatValue = distribution.panYNew
+            if (distribution.listRequestViewportPx != 0f) {
+                listState.dispatchRawDelta(distribution.listRequestViewportPx)
+            }
         }
     }
 
@@ -175,6 +187,9 @@ internal class TopicZoomState(private val animationScope: CoroutineScope) {
      * per-event pinch correction. Interruptible: a new pinch cancels [releaseJob].
      */
     fun settleAnchoredTo(targetScale: Float, anchorX: Float, anchorY: Float, listState: LazyListState) {
+        // The live gesture wins (review finding) : a chip tap landing mid-pinch must not start a
+        // second producer — the gesture's own release will settle.
+        if (gestureEngaged) return
         if (targetScale == scale.floatValue) return
         releaseJob?.cancel()
         val fromScale = scale.floatValue
@@ -189,10 +204,12 @@ internal class TopicZoomState(private val animationScope: CoroutineScope) {
                 val viewportX = (anchorX - panX.floatValue) / prevScale
                 panX.floatValue = (anchorX - viewportX * frameScale)
                     .coerceIn(panXRange(frameScale, widthPx))
-                val viewportY = (anchorY - panY.floatValue) / prevScale
+                val panYOld = panY.floatValue
                 scale.floatValue = frameScale
                 reclampPanY()
-                val drift = viewportY * frameScale + panY.floatValue - anchorY
+                // Pure drift (review finding — same function the math tests pin).
+                val drift =
+                    anchoredVerticalDrift(anchorY, panYOld, prevScale, frameScale, panY.floatValue)
                 moveContentUp(drift, listState)
                 prevScale = frameScale
             }
@@ -245,6 +262,7 @@ internal fun Modifier.topicMagnifier(
         state.viewportWidthPx = size.width.toFloat()
         state.viewportHeightPx = size.height.toFloat()
         val engaged = trackMagnifierGesture(state, listState)
+        state.releaseGesture()
         if (!engaged) return@awaitEachGesture
         // Release: snap near-rest scales back to 1×, cap rubber-banded ones — ANCHORED on the last
         // gesture position so the settle never jumps (panX converges into [0,0] on a snap to 1×).

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoom.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoom.kt
@@ -16,6 +16,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.AwaitPointerEventScope
+import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import kotlinx.coroutines.CoroutineScope
@@ -236,90 +238,7 @@ internal fun Modifier.topicMagnifier(
         if (state.zoomed) firstDown.consume()
         state.viewportWidthPx = size.width.toFloat()
         state.viewportHeightPx = size.height.toFloat()
-        var engaged = false
-        while (true) {
-            val event = awaitPointerEvent(PointerEventPass.Initial)
-            val pressed = event.changes.count { it.pressed }
-            if (pressed == 0) {
-                // Matrix finding (bench, line « pinch après swipe armé ») : when both fingers lift
-                // in the SAME frame, exiting without consuming lets a sibling detector see ITS
-                // pointer released cleanly — the armed page swipe then completes and COMMITS the
-                // accumulated offset. An engaged magnifier owns the whole gesture, ups included.
-                if (engaged) event.changes.forEach { it.consume() }
-                break
-            }
-            when {
-                pressed >= 2 -> {
-                    if (!engaged) {
-                        // Engage on the SECOND pointer only: a plain tap must not freeze an
-                        // in-flight snap animation, but a new pinch interrupts it (hypothesis 8).
-                        // The fling stop is SEQUENCED with the controlled mutations by the
-                        // engage/buffer contract in TopicZoomState (#937 framing, Sol).
-                        state.engage(listState)
-                        engaged = true
-                    }
-                    // calculateZoom guards its degenerate cases, but a non-positive ratio would
-                    // trip pinchStep's precondition mid-gesture — neutralise it defensively.
-                    val zoom = event.calculateZoom().takeIf { it > 0f } ?: 1f
-                    // PREVIOUS centroid (gate Sol r1) : pinchStep anchors around the pre-move
-                    // position, then the centroid translation is applied once through `pan`.
-                    // Anchoring on the CURRENT centroid would re-inject the translation with the
-                    // wrong base (1×→2×, centroid 400→500 : panX must be −300, not −400) and the
-                    // matrix would measure a pinch that slides under the fingers.
-                    val centroid = event.calculateCentroid(useCurrent = false)
-                    val pan = event.calculatePan()
-                    val scaleOld = state.scale.floatValue
-                    val panYOld = state.panY.floatValue
-                    val zoomStep = pinchStep(
-                        current = state.currentTransform(),
-                        centroidX = centroid.x,
-                        centroidY = centroid.y,
-                        zoomFactor = zoom,
-                        widthPx = size.width.toFloat(),
-                    )
-                    // X anchoring + new scale come from the tested math; the step's scrollByPx is
-                    // superseded by the panY-aware drift below (bottom-edge contract amendment).
-                    state.apply(zoomStep)
-                    val scale = state.scale.floatValue
-                    state.panX.floatValue =
-                        panStep(state.panX.floatValue, pan.x, scale, size.width.toFloat())
-                    // Y drift of the content point under the (previous) centroid, panY included:
-                    // where it would land minus the finger — moved back up, finger pan folded in.
-                    val viewportY = (centroid.y - panYOld) / scaleOld
-                    val drift = viewportY * scale + state.panY.floatValue - centroid.y
-                    state.moveContentUp(drift - pan.y, listState)
-                    state.lastAnchorX = centroid.x + pan.x
-                    state.lastAnchorY = centroid.y + pan.y
-                    event.changes.forEach { it.consume() }
-                }
-                engaged || state.zoomed -> {
-                    // One-finger pan while zoomed — and, once ENGAGED, capture is held until the
-                    // last `up` even if the scale came back to exactly 1× mid-gesture (gate Sol
-                    // r1) : releasing the consumption there would let swipe/scroll/PTR re-engage
-                    // in the middle of the same physical gesture. At 1× the controlled path
-                    // degrades gracefully (panX clamped to 0, dispatchRawDelta 1:1).
-                    if (!engaged) {
-                        // Same engage/buffer contract as the pinch branch.
-                        state.engage(listState)
-                        engaged = true
-                    }
-                    val change = event.changes.first { it.pressed }
-                    val delta = change.position - change.previousPosition
-                    val scale = state.scale.floatValue
-                    state.panX.floatValue =
-                        panStep(state.panX.floatValue, delta.x, scale, size.width.toFloat())
-                    state.moveContentUp(-delta.y, listState)
-                    state.lastAnchorX = change.position.x
-                    state.lastAnchorY = change.position.y
-                    event.changes.forEach { it.consume() }
-                }
-                else -> {
-                    // 1× single pointer: observe WITHOUT consuming — every existing gesture stays
-                    // intact, and a second pointer landing mid-drag (armed swipe included) still
-                    // upgrades this same gesture into a pinch on the next event.
-                }
-            }
-        }
+        val engaged = trackMagnifierGesture(state, listState)
         if (!engaged) return@awaitEachGesture
         // Release: snap near-rest scales back to 1×, cap rubber-banded ones — ANCHORED on the last
         // gesture position so the settle never jumps (panX converges into [0,0] on a snap to 1×).
@@ -330,4 +249,109 @@ internal fun Modifier.topicMagnifier(
             listState = listState,
         )
     }
+}
+
+/**
+ * The magnifier event loop — Initial pass, one iteration per pointer event. Returns whether the
+ * gesture ever ENGAGED (2nd pointer, or one-finger while zoomed). Once engaged, capture is held
+ * until the last `up` even if the scale came back to exactly 1× mid-gesture (gate Sol r1) — and
+ * the final up frame is consumed too (bench matrix finding : both fingers lifting in the SAME
+ * frame otherwise let an armed sibling swipe complete and COMMIT).
+ */
+private suspend fun AwaitPointerEventScope.trackMagnifierGesture(
+    state: TopicZoomState,
+    listState: LazyListState,
+): Boolean {
+    var engaged = false
+    while (true) {
+        val event = awaitPointerEvent(PointerEventPass.Initial)
+        val released = event.changes.none { it.pressed }
+        if (released && engaged) event.changes.forEach { it.consume() }
+        if (released) return engaged
+        engaged = handleMagnifierFrame(state, listState, event, engaged)
+    }
+}
+
+/**
+ * One pointer frame of the magnifier. Engages on the SECOND pointer — a plain tap must not freeze
+ * an in-flight snap animation, but a new pinch interrupts it (hypothesis 8) — or on one finger
+ * while already zoomed. The fling stop is SEQUENCED with the controlled mutations by the
+ * engage/buffer contract in TopicZoomState (#937 framing, Sol). A 1× single pointer observes
+ * WITHOUT consuming : every existing gesture stays intact, and a second pointer landing mid-drag
+ * (armed swipe included) still upgrades this same gesture into a pinch on the next event. At 1×
+ * while engaged, the controlled pan degrades gracefully (panX clamped to 0, dispatchRawDelta 1:1).
+ */
+private fun AwaitPointerEventScope.handleMagnifierFrame(
+    state: TopicZoomState,
+    listState: LazyListState,
+    event: PointerEvent,
+    wasEngaged: Boolean,
+): Boolean {
+    val pressed = event.changes.count { it.pressed }
+    val engaging = pressed >= 2 || wasEngaged || state.zoomed
+    if (!engaging) return false
+    if (!wasEngaged) state.engage(listState)
+    if (pressed >= 2) {
+        applyPinchFrame(state, listState, event, size.width.toFloat())
+    } else {
+        applyPanFrame(state, listState, event, size.width.toFloat())
+    }
+    event.changes.forEach { it.consume() }
+    return true
+}
+
+/** One one-finger pan frame while zoomed: bounded panX, real list scroll on Y (÷ scale). */
+private fun applyPanFrame(
+    state: TopicZoomState,
+    listState: LazyListState,
+    event: PointerEvent,
+    widthPx: Float,
+) {
+    val change = event.changes.first { it.pressed }
+    val delta = change.position - change.previousPosition
+    val scale = state.scale.floatValue
+    state.panX.floatValue = panStep(state.panX.floatValue, delta.x, scale, widthPx)
+    state.moveContentUp(-delta.y, listState)
+    state.lastAnchorX = change.position.x
+    state.lastAnchorY = change.position.y
+}
+
+/**
+ * One pinch frame: anchored scale step (tested math) + finger pan folded in. The PREVIOUS
+ * centroid anchors the step (gate Sol r1) : pinchStep works around the pre-move position, then
+ * the centroid translation is applied once through `pan` — anchoring on the CURRENT centroid
+ * would re-inject the translation with the wrong base (1×→2×, centroid 400→500 : panX must be
+ * −300, not −400) and the pinch would slide under the fingers. The step's scrollByPx is
+ * superseded by the panY-aware drift (bottom-edge contract amendment).
+ */
+private fun applyPinchFrame(
+    state: TopicZoomState,
+    listState: LazyListState,
+    event: PointerEvent,
+    widthPx: Float,
+) {
+    // calculateZoom guards its degenerate cases, but a non-positive ratio would trip
+    // pinchStep's precondition mid-gesture — neutralise it defensively.
+    val zoom = event.calculateZoom().takeIf { it > 0f } ?: 1f
+    val centroid = event.calculateCentroid(useCurrent = false)
+    val pan = event.calculatePan()
+    val scaleOld = state.scale.floatValue
+    val panYOld = state.panY.floatValue
+    val zoomStep = pinchStep(
+        current = state.currentTransform(),
+        centroidX = centroid.x,
+        centroidY = centroid.y,
+        zoomFactor = zoom,
+        widthPx = widthPx,
+    )
+    state.apply(zoomStep)
+    val scale = state.scale.floatValue
+    state.panX.floatValue = panStep(state.panX.floatValue, pan.x, scale, widthPx)
+    // Y drift of the content point under the (previous) centroid, panY included: where it
+    // would land minus the finger — moved back up, finger pan folded in.
+    val viewportY = (centroid.y - panYOld) / scaleOld
+    val drift = viewportY * scale + state.panY.floatValue - centroid.y
+    state.moveContentUp(drift - pan.y, listState)
+    state.lastAnchorX = centroid.x + pan.x
+    state.lastAnchorY = centroid.y + pan.y
 }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoom.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoom.kt
@@ -1,0 +1,289 @@
+package fr.forumhfr.redface2.feature.topic
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.calculateCentroid
+import androidx.compose.foundation.gestures.calculatePan
+import androidx.compose.foundation.gestures.calculateZoom
+import androidx.compose.foundation.gestures.stopScroll
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+// POC #182 (issue #935) — global ephemeral magnifier, RF1 spirit. THROWAWAY BRANCH: this file
+// exists to measure the §4 gate criteria (gesture matrix, P95 frames, sharpness, heap); the
+// production tranche (#937) will re-derive from the POC relevé. Contract summary (§2.1):
+// 1× = every existing gesture intact ; PINCHING = a second pointer cancels any uncommitted swipe,
+// scale anchors the content under the centroid ; ZOOMED = one-finger pan (X = bounded layer
+// translation, Y = REAL list scrolling) while swipe/PTR/double-tap/selection are suspended ;
+// release ≤ 1.03 snaps back to rest ; reset on page/topic change (composition-keyed state).
+
+private const val ZOOM_SNAP_MILLIS = 200
+
+/**
+ * POC #182 — true while the reader is magnified (> 1×). Read by the post cards to suspend text
+ * selection (the `selectable` seam) without threading a parameter through the whole call chain.
+ */
+internal val LocalTopicZoomed = compositionLocalOf { false }
+
+/**
+ * POC #182 — the magnifier state. Scale and panX are [mutableFloatStateOf] so the draw phase reads
+ * them per frame without recomposition (same pattern as the swipe's dragOffset). The state lives in
+ * the Loaded composition keyed on the page identity: a page or topic change resets to 1× by
+ * construction (ephemeral contract — no rememberSaveable, process restore lands at 1×).
+ */
+internal class TopicZoomState(private val animationScope: CoroutineScope) {
+    val scale = mutableFloatStateOf(1f)
+    val panX = mutableFloatStateOf(0f)
+
+    /**
+     * CONTRACT AMENDMENT (POC iter 1, S25 field report) — bounded vertical layer translation,
+     * complement of the real list scroll. The pure「Y = real scrolling」model cannot show the
+     * BOTTOM of the page zoomed: at max scroll the anchoring delta clamps and the last post
+     * escapes below the visible `H/scale` window. panY ∈ [H×(1−scale), 0] pans across the SCALED
+     * RENDER of the already-composed viewport only — the §2.1 virtualisation objection (never
+     * reveal uncomposed items) stays honoured. Non-zero ONLY once the list scroll is exhausted;
+     * unwound FIRST when panning back. To fold into §2.1 + TopicZoomMath tests at step 3 (#937).
+     */
+    val panY = mutableFloatStateOf(0f)
+
+    /** True past the snap threshold — gates swipe/PTR/double-tap/selection at the call sites. */
+    val zoomed: Boolean
+        get() = scale.floatValue > 1f
+
+    /** Tracks the in-flight release/reset animation so a new gesture can cancel it deterministically. */
+    var releaseJob: Job? = null
+
+    /**
+     * Gate Sol (panY amendment) : a LazyList fling still running when the magnifier engages would
+     * be a SECOND producer mutating the scroll under our dispatchRawDelta corrections. One-shot
+     * cancellation via a UserInput-priority no-op scroll session.
+     */
+    fun stopListFling(listState: LazyListState) {
+        animationScope.launch { listState.stopScroll() }
+    }
+
+    /**
+     * Last gesture anchor (local, untransformed coords) + viewport size, recorded by the gesture so
+     * the settle animation and the reset chip can anchor their scale change. Plain vars: they are
+     * never read in composition.
+     */
+    var lastAnchorX = 0f
+    var lastAnchorY = 0f
+    var viewportWidthPx = 0f
+    var viewportHeightPx = 0f
+
+    fun currentTransform() = ZoomTransform(scale.floatValue, panX.floatValue)
+
+    fun apply(step: PinchStep) {
+        scale.floatValue = step.scaleNew
+        panX.floatValue = step.panXNew
+        reclampPanY()
+    }
+
+    /** The panY bound depends on the scale — re-clamp after every scale change. */
+    fun reclampPanY() {
+        panY.floatValue = panY.floatValue.coerceIn(viewportHeightPx * (1f - scale.floatValue), 0f)
+    }
+
+    /**
+     * Moves the CONTENT up by [deltaScreenPx] screen pixels (negative = down), distributing
+     * between the real list scroll (preferred — unscaled viewport pixels) and the bounded [panY]
+     * complement. Upward: whatever the clamped scroll does not consume spills into panY (bottom
+     * edge). Downward: panY unwinds back to 0 FIRST, then the list scrolls — panY is never left
+     * engaged while scroll headroom exists in the visible direction.
+     */
+    fun moveContentUp(deltaScreenPx: Float, listState: LazyListState) {
+        val s = scale.floatValue
+        val minPanY = viewportHeightPx * (1f - s)
+        if (deltaScreenPx >= 0f) {
+            val consumed = listState.dispatchRawDelta(deltaScreenPx / s)
+            val rest = deltaScreenPx - consumed * s
+            panY.floatValue = (panY.floatValue - rest).coerceIn(minPanY, 0f)
+        } else {
+            val down = -deltaScreenPx
+            // Both bounds on the unwind (gate Sol) : equivalent under the invariant, robust if the
+            // state ever lands momentarily out of range (e.g. a reclamp raced a frame).
+            val oldPanY = panY.floatValue
+            val newPanY = (oldPanY + down).coerceIn(minPanY, 0f)
+            val usedByPanY = newPanY - oldPanY
+            panY.floatValue = newPanY
+            val remaining = down - usedByPanY
+            if (remaining > 0f) listState.dispatchRawDelta(-remaining / s)
+        }
+    }
+
+    /**
+     * Animated, ANCHORED return to a settled scale: snap to 1× or back to the 2.5× ceiling from
+     * the rubber band over [ZOOM_SNAP_MILLIS], keeping the content point under (anchorX, anchorY)
+     * stationary — the naive unanchored settle shrank the content toward the top-left origin with
+     * no scroll compensation, so a release from deep zoom visibly jumped (S25 field report, POC
+     * iter 1). Each frame re-anchors pan X and dispatches the unscaled scroll delta, exactly the
+     * per-event pinch correction. Interruptible: a new pinch cancels [releaseJob].
+     */
+    fun settleAnchoredTo(targetScale: Float, anchorX: Float, anchorY: Float, listState: LazyListState) {
+        if (targetScale == scale.floatValue) return
+        releaseJob?.cancel()
+        val fromScale = scale.floatValue
+        val widthPx = viewportWidthPx
+        releaseJob = animationScope.launch {
+            // Gate Sol : the settle dispatches scroll deltas too — never with a live fling.
+            listState.stopScroll()
+            val progress = Animatable(0f)
+            var prevScale = fromScale
+            progress.animateTo(1f, tween(ZOOM_SNAP_MILLIS, easing = LinearOutSlowInEasing)) {
+                val frameScale = fromScale + (targetScale - fromScale) * value
+                val viewportX = (anchorX - panX.floatValue) / prevScale
+                panX.floatValue = (anchorX - viewportX * frameScale)
+                    .coerceIn(panXRange(frameScale, widthPx))
+                val viewportY = (anchorY - panY.floatValue) / prevScale
+                scale.floatValue = frameScale
+                reclampPanY()
+                val drift = viewportY * frameScale + panY.floatValue - anchorY
+                moveContentUp(drift, listState)
+                prevScale = frameScale
+            }
+        }
+    }
+}
+
+@Composable
+internal fun rememberTopicZoomState(pageKey: Int, animationScope: CoroutineScope): TopicZoomState =
+    // Keyed on the loaded page: since #895 the topic composition survives page changes, so the
+    // reset-on-page-change contract hangs on this key. A topic change replaces the whole route
+    // (fresh composition), covering the reset-on-topic-change leg.
+    remember(pageKey) { TopicZoomState(animationScope) }
+
+/**
+ * POC #182 — the magnifier gesture. Listens on the INITIAL pass so that, once a second pointer is
+ * down, consuming the position changes starves every child/sibling detector in their Main pass:
+ * the in-flight page swipe sees consumed changes and cancels into its spring-back (experimental
+ * cancellation — the tested hardening is #936), the list stops scrolling, PTR never engages.
+ * Plain taps are NOT consumed (down/up pass through), which is exactly the « nominal mode »
+ * hypothesis of the #935 matrix (taps/long-press preserved at > 1×) — measured, not assumed.
+ *
+ * Sits BEFORE the zoom graphicsLayer in the modifier chain (same coordinate rule as
+ * `topicPageSwipe`): centroids are read in the untransformed local space that `TopicZoomMath`
+ * models. One state mutation set per pointer event; frame coalescing is asserted at the relevé.
+ */
+internal fun Modifier.topicMagnifier(
+    state: TopicZoomState,
+    listState: LazyListState,
+): Modifier = pointerInput(state) {
+    awaitEachGesture {
+        val firstDown = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+        // MODE REPLIÉ (contract fallback, acted at POC iter 2 — S25 field report) : child
+        // hit-testing does NOT follow the draw-only zoom layer, so a tap at >1× lands on the
+        // UNTRANSFORMED coordinates — dead at best, an invisible neighbour at worst (it only
+        // « worked » near 1× where both spaces almost coincide). Taps and long-presses are
+        // therefore deterministically INERT while zoomed : the down itself is consumed on the
+        // Initial pass, children never even start a gesture. Interaction path at >1× = reset
+        // (chip or snap) then tap — announced to testers before any A delivery (§7.5).
+        if (state.zoomed) firstDown.consume()
+        state.viewportWidthPx = size.width.toFloat()
+        state.viewportHeightPx = size.height.toFloat()
+        var engaged = false
+        while (true) {
+            val event = awaitPointerEvent(PointerEventPass.Initial)
+            val pressed = event.changes.count { it.pressed }
+            if (pressed == 0) {
+                // Matrix finding (bench, line « pinch après swipe armé ») : when both fingers lift
+                // in the SAME frame, exiting without consuming lets a sibling detector see ITS
+                // pointer released cleanly — the armed page swipe then completes and COMMITS the
+                // accumulated offset. An engaged magnifier owns the whole gesture, ups included.
+                if (engaged) event.changes.forEach { it.consume() }
+                break
+            }
+            when {
+                pressed >= 2 -> {
+                    if (!engaged) {
+                        // Engage on the SECOND pointer only: a plain tap must not freeze an
+                        // in-flight snap animation, but a new pinch interrupts it (hypothesis 8).
+                        state.releaseJob?.cancel()
+                        state.stopListFling(listState)
+                        engaged = true
+                    }
+                    // calculateZoom guards its degenerate cases, but a non-positive ratio would
+                    // trip pinchStep's precondition mid-gesture — neutralise it defensively.
+                    val zoom = event.calculateZoom().takeIf { it > 0f } ?: 1f
+                    // PREVIOUS centroid (gate Sol r1) : pinchStep anchors around the pre-move
+                    // position, then the centroid translation is applied once through `pan`.
+                    // Anchoring on the CURRENT centroid would re-inject the translation with the
+                    // wrong base (1×→2×, centroid 400→500 : panX must be −300, not −400) and the
+                    // matrix would measure a pinch that slides under the fingers.
+                    val centroid = event.calculateCentroid(useCurrent = false)
+                    val pan = event.calculatePan()
+                    val scaleOld = state.scale.floatValue
+                    val panYOld = state.panY.floatValue
+                    val zoomStep = pinchStep(
+                        current = state.currentTransform(),
+                        centroidX = centroid.x,
+                        centroidY = centroid.y,
+                        zoomFactor = zoom,
+                        widthPx = size.width.toFloat(),
+                    )
+                    // X anchoring + new scale come from the tested math; the step's scrollByPx is
+                    // superseded by the panY-aware drift below (bottom-edge contract amendment).
+                    state.apply(zoomStep)
+                    val scale = state.scale.floatValue
+                    state.panX.floatValue =
+                        panStep(state.panX.floatValue, pan.x, scale, size.width.toFloat())
+                    // Y drift of the content point under the (previous) centroid, panY included:
+                    // where it would land minus the finger — moved back up, finger pan folded in.
+                    val viewportY = (centroid.y - panYOld) / scaleOld
+                    val drift = viewportY * scale + state.panY.floatValue - centroid.y
+                    state.moveContentUp(drift - pan.y, listState)
+                    state.lastAnchorX = centroid.x + pan.x
+                    state.lastAnchorY = centroid.y + pan.y
+                    event.changes.forEach { it.consume() }
+                }
+                engaged || state.zoomed -> {
+                    // One-finger pan while zoomed — and, once ENGAGED, capture is held until the
+                    // last `up` even if the scale came back to exactly 1× mid-gesture (gate Sol
+                    // r1) : releasing the consumption there would let swipe/scroll/PTR re-engage
+                    // in the middle of the same physical gesture. At 1× the controlled path
+                    // degrades gracefully (panX clamped to 0, dispatchRawDelta 1:1).
+                    if (!engaged) {
+                        state.releaseJob?.cancel()
+                        state.stopListFling(listState)
+                        engaged = true
+                    }
+                    val change = event.changes.first { it.pressed }
+                    val delta = change.position - change.previousPosition
+                    val scale = state.scale.floatValue
+                    state.panX.floatValue =
+                        panStep(state.panX.floatValue, delta.x, scale, size.width.toFloat())
+                    state.moveContentUp(-delta.y, listState)
+                    state.lastAnchorX = change.position.x
+                    state.lastAnchorY = change.position.y
+                    event.changes.forEach { it.consume() }
+                }
+                else -> {
+                    // 1× single pointer: observe WITHOUT consuming — every existing gesture stays
+                    // intact, and a second pointer landing mid-drag (armed swipe included) still
+                    // upgrades this same gesture into a pinch on the next event.
+                }
+            }
+        }
+        if (!engaged) return@awaitEachGesture
+        // Release: snap near-rest scales back to 1×, cap rubber-banded ones — ANCHORED on the last
+        // gesture position so the settle never jumps (panX converges into [0,0] on a snap to 1×).
+        state.settleAnchoredTo(
+            targetScale = resolveScaleOnRelease(state.scale.floatValue),
+            anchorX = state.lastAnchorX,
+            anchorY = state.lastAnchorY,
+            listState = listState,
+        )
+    }
+}

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoom.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoom.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.gestures.calculateZoom
 import androidx.compose.foundation.gestures.stopScroll
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
@@ -26,8 +27,11 @@ import kotlinx.coroutines.launch
 // production tranche (#937) will re-derive from the POC relevé. Contract summary (§2.1):
 // 1× = every existing gesture intact ; PINCHING = a second pointer cancels any uncommitted swipe,
 // scale anchors the content under the centroid ; ZOOMED = one-finger pan (X = bounded layer
-// translation, Y = REAL list scrolling) while swipe/PTR/double-tap/selection are suspended ;
-// release ≤ 1.03 snaps back to rest ; reset on page/topic change (composition-keyed state).
+// translation, Y = real list scrolling + bounded panY complement at the bottom edge) while
+// swipe/PTR/double-tap/selection are suspended AND taps/long-presses are deterministically INERT
+// (REPLIED MODE, acted at POC iter 2 : child hit-testing does not follow the draw-only layer —
+// interact = reset via the chip or the snap, then tap) ; release ≤ 1.03 snaps back to rest ;
+// reset on page AND topic change (state keyed on the full route identity).
 
 private const val ZOOM_SNAP_MILLIS = 200
 
@@ -66,12 +70,30 @@ internal class TopicZoomState(private val animationScope: CoroutineScope) {
     var releaseJob: Job? = null
 
     /**
-     * Gate Sol (panY amendment) : a LazyList fling still running when the magnifier engages would
-     * be a SECOND producer mutating the scroll under our dispatchRawDelta corrections. One-shot
-     * cancellation via a UserInput-priority no-op scroll session.
+     * #937 framing (Sol) — a live LazyList fling is a SECOND producer racing our controlled
+     * scroll mutations. `stopScroll` is suspend and [AwaitPointerEventScope] is a RESTRICTED
+     * suspension scope (the compiler forbids calling it inline in the gesture), so the stop runs
+     * on [animationScope] and [moveContentUp] BUFFERS list deltas until it has completed —
+     * sequenced, no delta lost, never two producers.
      */
-    fun stopListFling(listState: LazyListState) {
-        animationScope.launch { listState.stopScroll() }
+    private var stopFlingJob: Job? = null
+    private var pendingDeltaScreenPx = 0f
+
+    /** Called once per gesture, when the magnifier takes ownership (2nd pointer or zoomed pan). */
+    fun engage(listState: LazyListState) {
+        releaseJob?.cancel()
+        pendingDeltaScreenPx = 0f
+        stopFlingJob = animationScope.launch { listState.stopScroll() }
+    }
+
+    /**
+     * #937 framing (Sol) — the previous page's state must not keep mutating the SHARED LazyList
+     * after `remember(pageKey)` replaced it : a 200 ms settle outliving its composition would
+     * scroll the NEW page. Called from a DisposableEffect in [rememberTopicZoomState].
+     */
+    fun cancelJobs() {
+        releaseJob?.cancel()
+        stopFlingJob?.cancel()
     }
 
     /**
@@ -105,6 +127,18 @@ internal class TopicZoomState(private val animationScope: CoroutineScope) {
      * engaged while scroll headroom exists in the visible direction.
      */
     fun moveContentUp(deltaScreenPx: Float, listState: LazyListState) {
+        // Fling stop still in flight : buffer instead of racing it (see [engage]).
+        val stop = stopFlingJob
+        if (stop != null && !stop.isCompleted) {
+            pendingDeltaScreenPx += deltaScreenPx
+            return
+        }
+        val delta = deltaScreenPx + pendingDeltaScreenPx
+        pendingDeltaScreenPx = 0f
+        applyContentDelta(delta, listState)
+    }
+
+    private fun applyContentDelta(deltaScreenPx: Float, listState: LazyListState) {
         val s = scale.floatValue
         val minPanY = viewportHeightPx * (1f - s)
         if (deltaScreenPx >= 0f) {
@@ -159,23 +193,32 @@ internal class TopicZoomState(private val animationScope: CoroutineScope) {
 }
 
 @Composable
-internal fun rememberTopicZoomState(pageKey: Int, animationScope: CoroutineScope): TopicZoomState =
-    // Keyed on the loaded page: since #895 the topic composition survives page changes, so the
-    // reset-on-page-change contract hangs on this key. A topic change replaces the whole route
-    // (fresh composition), covering the reset-on-topic-change leg.
-    remember(pageKey) { TopicZoomState(animationScope) }
+internal fun rememberTopicZoomState(pageKey: Any, animationScope: CoroutineScope): TopicZoomState {
+    // Keyed on the FULL route identity (cat, post, page) — never the page alone : since #895 the
+    // topic composition survives page changes of the SAME topic, and two topics at the same page
+    // must not share a zoom (§2.1). The DisposableEffect cancels the replaced state's animation
+    // jobs : they run on the composition-scoped animationScope, which SURVIVES the key change —
+    // an orphaned 200 ms settle would keep scrolling the new page (#937 framing, Sol).
+    val state = remember(pageKey) { TopicZoomState(animationScope) }
+    DisposableEffect(state) {
+        onDispose { state.cancelJobs() }
+    }
+    return state
+}
 
 /**
- * POC #182 — the magnifier gesture. Listens on the INITIAL pass so that, once a second pointer is
+ * #182 — the magnifier gesture. Listens on the INITIAL pass so that, once a second pointer is
  * down, consuming the position changes starves every child/sibling detector in their Main pass:
- * the in-flight page swipe sees consumed changes and cancels into its spring-back (experimental
- * cancellation — the tested hardening is #936), the list stops scrolling, PTR never engages.
- * Plain taps are NOT consumed (down/up pass through), which is exactly the « nominal mode »
- * hypothesis of the #935 matrix (taps/long-press preserved at > 1×) — measured, not assumed.
+ * the in-flight page swipe cancels into its spring-back (its own native multi-touch defense is
+ * #936 — this consumption is defense in depth), the list stops scrolling, PTR never engages.
+ * While ZOOMED, the down itself is consumed (REPLIED MODE) : taps and long-presses are
+ * deterministically inert at > 1× — child hit-testing does not follow the draw-only layer, so a
+ * zoomed tap would land on untransformed coordinates (dead at best, an invisible neighbour at
+ * worst). Interaction path at > 1× = reset (chip or snap) then tap.
  *
  * Sits BEFORE the zoom graphicsLayer in the modifier chain (same coordinate rule as
  * `topicPageSwipe`): centroids are read in the untransformed local space that `TopicZoomMath`
- * models. One state mutation set per pointer event; frame coalescing is asserted at the relevé.
+ * models. One state mutation set per pointer event.
  */
 internal fun Modifier.topicMagnifier(
     state: TopicZoomState,
@@ -210,8 +253,9 @@ internal fun Modifier.topicMagnifier(
                     if (!engaged) {
                         // Engage on the SECOND pointer only: a plain tap must not freeze an
                         // in-flight snap animation, but a new pinch interrupts it (hypothesis 8).
-                        state.releaseJob?.cancel()
-                        state.stopListFling(listState)
+                        // The fling stop is SEQUENCED with the controlled mutations by the
+                        // engage/buffer contract in TopicZoomState (#937 framing, Sol).
+                        state.engage(listState)
                         engaged = true
                     }
                     // calculateZoom guards its degenerate cases, but a non-positive ratio would
@@ -255,8 +299,8 @@ internal fun Modifier.topicMagnifier(
                     // in the middle of the same physical gesture. At 1× the controlled path
                     // degrades gracefully (panX clamped to 0, dispatchRawDelta 1:1).
                     if (!engaged) {
-                        state.releaseJob?.cancel()
-                        state.stopListFling(listState)
+                        // Same engage/buffer contract as the pinch branch.
+                        state.engage(listState)
                         engaged = true
                     }
                     val change = event.changes.first { it.pressed }

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoom.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoom.kt
@@ -91,11 +91,17 @@ internal class TopicZoomState(private val animationScope: CoroutineScope) {
     /**
      * #937 framing (Sol) — the previous page's state must not keep mutating the SHARED LazyList
      * after `remember(pageKey)` replaced it : a 200 ms settle outliving its composition would
-     * scroll the NEW page. Called from a DisposableEffect in [rememberTopicZoomState].
+     * scroll the NEW page. Called from a DisposableEffect in [rememberTopicZoomState]. The floats
+     * are also parked at rest (validation 5.5) : a cancelled mid-settle state must never be left
+     * partially animated — every other cancellation path hands control to a new pilot (engage),
+     * this one has none.
      */
     fun cancelJobs() {
         releaseJob?.cancel()
         stopFlingJob?.cancel()
+        scale.floatValue = 1f
+        panX.floatValue = 0f
+        panY.floatValue = 0f
     }
 
     /**
@@ -307,7 +313,9 @@ private fun applyPanFrame(
     event: PointerEvent,
     widthPx: Float,
 ) {
-    val change = event.changes.first { it.pressed }
+    // firstOrNull (validation 5.5) : a transient frame where every pointer just lifted must not
+    // crash — the release branch of the loop handles it on the next event.
+    val change = event.changes.firstOrNull { it.pressed } ?: return
     val delta = change.position - change.previousPosition
     val scale = state.scale.floatValue
     state.panX.floatValue = panStep(state.panX.floatValue, delta.x, scale, widthPx)

--- a/feature/topic/src/main/res/values/strings.xml
+++ b/feature/topic/src/main/res/values/strings.xml
@@ -117,6 +117,8 @@
     <string name="topic_poll_show">(afficher)</string>
     <string name="topic_poll_hide">(masquer)</string>
     <string name="topic_retry">Réessayer</string>
+    <string name="topic_zoom_reset_chip">1×</string>
+    <string name="topic_zoom_reset">Revenir au zoom normal</string>
     <string name="topic_page_previous">Précédent</string>
     <string name="topic_page_next">Suivant</string>
     <string name="topic_page_indicator">page %1$d / %2$d</string>

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoomGestureTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoomGestureTest.kt
@@ -1,0 +1,402 @@
+package fr.forumhfr.redface2.feature.topic
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.unit.dp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * #937 — instrumented gesture matrix of the #182 magnifier (the production tranche of the GO POC
+ * #935). Each test is one line of the framing's minimal matrix; the device-level lines (P95,
+ * sharpness, PTR wiring, reset chip end-to-end) are covered by the dated bench relevés on #935.
+ *
+ * Harness: a 360×600 dp Box carrying [topicMagnifier] around a plain LazyColumn — and, for the
+ * coexistence lines, [topicPageSwipe] stacked the way TopicScreen stacks them. Geometry at
+ * xxhdpi: 3 px/dp, box = 1080×1800 px.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h780dp-xxhdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class TopicZoomGestureTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private lateinit var zoomState: TopicZoomState
+    private lateinit var listState: LazyListState
+    private lateinit var swipeDragOffset: androidx.compose.runtime.MutableFloatState
+
+    /** Mounts the magnifier harness; [withSwipe] stacks the page swipe under it like TopicScreen. */
+    private fun mount(
+        withSwipe: Boolean = false,
+        onOpenPage: (Int) -> Unit = {},
+        pageKey: () -> Any = { 1 },
+    ) {
+        compose.setContent {
+            val scope = rememberCoroutineScope()
+            listState = remember { LazyListState() }
+            zoomState = rememberTopicZoomState(pageKey = pageKey(), animationScope = scope)
+            val dragOffset = remember { mutableFloatStateOf(0f) }.also { swipeDragOffset = it }
+            val haptics = LocalHapticFeedback.current
+            var modifier = Modifier
+                .size(360.dp, 600.dp)
+                .testTag("zoom")
+                .topicMagnifier(zoomState, listState)
+            if (withSwipe) {
+                modifier = modifier.topicPageSwipe(
+                    currentPage = 5,
+                    totalPages = { 10 },
+                    dragOffset = dragOffset,
+                    handlers = TopicSwipeHandlers(
+                        haptics = haptics,
+                        onOpenPage = onOpenPage,
+                        enabled = { !zoomState.zoomed },
+                        leftGestureInsetPx = { 0 },
+                        rightGestureInsetPx = { 0 },
+                    ),
+                )
+            }
+            Box(modifier) {
+                LazyColumn(state = listState) {
+                    items(count = 200) { i ->
+                        Text("post $i", Modifier.fillMaxWidth().height(48.dp))
+                    }
+                }
+            }
+        }
+    }
+
+    private fun pinchOut(gapStartPx: Float = 300f, gapEndPx: Float = 750f, steps: Int = 12) {
+        compose.onNodeWithTag("zoom").performTouchInput {
+            down(0, center - Offset(0f, gapStartPx / 2f))
+            down(1, center + Offset(0f, gapStartPx / 2f))
+            repeat(steps) { i ->
+                val gap = gapStartPx + (gapEndPx - gapStartPx) * (i + 1) / steps
+                updatePointerTo(0, center - Offset(0f, gap / 2f))
+                updatePointerTo(1, center + Offset(0f, gap / 2f))
+                move()
+            }
+            up(0)
+            up(1)
+        }
+    }
+
+    @Test
+    fun `a two-finger pinch engages the scale and settles inside the bounds`() {
+        mount()
+        pinchOut()
+        compose.waitForIdle()
+
+        val scale = zoomState.scale.floatValue
+        assertTrue("pinch must engage the zoom (scale=$scale)", scale > 1.5f)
+        assertTrue("release must cap at the ceiling", scale <= MAX_ZOOM_SCALE + 0.001f)
+        val panX = zoomState.panX.floatValue
+        assertTrue("panX must stay in its bounds", panX <= 0f && panX >= 1080f * (1f - scale) - 1f)
+    }
+
+    @Test
+    fun `a pinch back to rest snaps to exactly one and releases the transform`() {
+        mount()
+        pinchOut()
+        compose.waitForIdle()
+        compose.onNodeWithTag("zoom").performTouchInput {
+            down(0, center - Offset(0f, 400f))
+            down(1, center + Offset(0f, 400f))
+            repeat(12) { i ->
+                val gap = 800f - 730f * (i + 1) / 12
+                updatePointerTo(0, center - Offset(0f, gap / 2f))
+                updatePointerTo(1, center + Offset(0f, gap / 2f))
+                move()
+            }
+            up(0)
+            up(1)
+        }
+        compose.waitForIdle()
+
+        assertEquals("snap must land at exactly 1x", 1f, zoomState.scale.floatValue, 0.001f)
+        assertEquals("panX must collapse with the snap", 0f, zoomState.panX.floatValue, 0.5f)
+        assertEquals("panY must collapse with the snap", 0f, zoomState.panY.floatValue, 0.5f)
+    }
+
+    @Test
+    fun `a third pointer keeps participating without breaking the bounds`() {
+        mount()
+        compose.onNodeWithTag("zoom").performTouchInput {
+            down(0, center - Offset(0f, 150f))
+            down(1, center + Offset(0f, 150f))
+            repeat(4) { i ->
+                val gap = 300f + 200f * (i + 1) / 4
+                updatePointerTo(0, center - Offset(0f, gap / 2f))
+                updatePointerTo(1, center + Offset(0f, gap / 2f))
+                move()
+            }
+        }
+        val scaleWithTwo = zoomState.scale.floatValue
+        compose.onNodeWithTag("zoom").performTouchInput {
+            down(2, center + Offset(200f, 0f))
+            // The two first pointers stay PUT: only the third moves. If only「the first two」
+            // fed the math, the scale would not change (framing arbitration 3, contractualised).
+            repeat(4) { i ->
+                updatePointerTo(2, center + Offset(200f + 60f * (i + 1), 0f))
+                move()
+            }
+            up(0); up(1); up(2)
+        }
+        compose.waitForIdle()
+
+        assertNotEquals(
+            "the third pointer must participate in the zoom computation",
+            scaleWithTwo,
+            zoomState.scale.floatValue,
+            0.005f,
+        )
+        val scale = zoomState.scale.floatValue
+        assertTrue("scale must stay within [1, ceiling]", scale >= 1f && scale <= MAX_ZOOM_SCALE + 0.001f)
+    }
+
+    @Test
+    fun `taps are inert while zoomed and work again after the reset`() {
+        var taps = 0
+        compose.setContent {
+            val scope = rememberCoroutineScope()
+            listState = remember { LazyListState() }
+            zoomState = rememberTopicZoomState(pageKey = 1, animationScope = scope)
+            Box(
+                Modifier
+                    .size(360.dp, 600.dp)
+                    .testTag("zoom")
+                    .topicMagnifier(zoomState, listState),
+            ) {
+                // The list ATTACHES the LazyListState : the settle's dispatchRawDelta would die
+                // silently inside its launch on a detached state (frozen scale, dead job).
+                LazyColumn(state = listState) {
+                    items(count = 200) { i -> Text("post $i", Modifier.fillMaxWidth().height(48.dp)) }
+                }
+                Box(
+                    Modifier
+                        .size(360.dp, 600.dp)
+                        .background(Color.Transparent)
+                        .clickable { taps++ },
+                )
+            }
+        }
+        // Sanity check of the harness itself : a tap at rest must reach the child.
+        compose.onNodeWithTag("zoom").performTouchInput { down(0, center); up(0) }
+        compose.waitForIdle()
+        assertEquals("harness: a tap at rest must click", 1, taps)
+
+        pinchOut()
+        compose.waitForIdle()
+        assertTrue(zoomState.zoomed)
+
+        compose.onNodeWithTag("zoom").performTouchInput { down(0, center); up(0) }
+        compose.waitForIdle()
+        assertEquals("a tap at >1x must be inert (replied mode)", 1, taps)
+
+        // Reset by GESTURE (the proven snap path) : the programmatic settle is covered by the
+        // dedicated settle test — here only the tap recovery matters.
+        compose.onNodeWithTag("zoom").performTouchInput {
+            down(0, center - Offset(0f, 400f))
+            down(1, center + Offset(0f, 400f))
+            repeat(12) { i ->
+                val gap = 800f - 730f * (i + 1) / 12
+                updatePointerTo(0, center - Offset(0f, gap / 2f))
+                updatePointerTo(1, center + Offset(0f, gap / 2f))
+                move()
+            }
+            up(0)
+            up(1)
+        }
+        compose.waitForIdle()
+        assertEquals("the gesture snap must land at rest", 1f, zoomState.scale.floatValue, 0.001f)
+        compose.onNodeWithTag("zoom").performTouchInput { down(0, center); up(0) }
+        compose.waitForIdle()
+        assertEquals("after the reset the tap must reach the child again", 2, taps)
+    }
+
+    @Test
+    fun `an uncommitted swipe is cancelled by the second finger with zero navigation`() {
+        var opened: Int? = null
+        mount(withSwipe = true, onOpenPage = { opened = it })
+        compose.onNodeWithTag("zoom").performTouchInput {
+            down(0, center)
+            repeat(10) { moveBy(0, Offset(-60f, 0f)) } // past slop AND past the commit distance
+            down(1, center + Offset(0f, 200f))
+            repeat(4) { i ->
+                updatePointerTo(0, center - Offset(600f, 40f * (i + 1)))
+                updatePointerTo(1, center + Offset(0f, 200f + 40f * (i + 1)))
+                move()
+            }
+            up(0)
+            up(1)
+        }
+        compose.waitForIdle()
+
+        assertNull("the armed swipe must cancel into the pinch, never navigate", opened)
+        assertTrue("the pinch must have engaged", zoomState.scale.floatValue > 1f)
+    }
+
+    @Test
+    fun `at rest the page swipe still commits exactly once under the magnifier`() {
+        var opened = 0
+        mount(withSwipe = true, onOpenPage = { opened++ })
+        compose.onNodeWithTag("zoom").performTouchInput {
+            down(0, center)
+            repeat(10) { moveBy(0, Offset(-60f, 0f)) }
+            up(0)
+        }
+        compose.waitForIdle()
+
+        assertEquals("the magnifier at 1x must not eat the swipe — exactly one navigation", 1, opened)
+    }
+
+    @Test
+    fun `capture is held until the last up even back at one`() {
+        mount(withSwipe = true, onOpenPage = { })
+        // Zoom in then back to ~1x WITHOUT lifting, then drag horizontally with the remaining
+        // finger: the magnifier must keep the capture (no swipe wake-up mid-gesture).
+        compose.onNodeWithTag("zoom").performTouchInput {
+            down(0, center - Offset(0f, 300f))
+            down(1, center + Offset(0f, 300f))
+            repeat(6) { i ->
+                val gap = 600f + 300f * (i + 1) / 6
+                updatePointerTo(0, center - Offset(0f, gap / 2f))
+                updatePointerTo(1, center + Offset(0f, gap / 2f))
+                move()
+            }
+            repeat(6) { i ->
+                val gap = 900f - 600f * (i + 1) / 6
+                updatePointerTo(0, center - Offset(0f, gap / 2f))
+                updatePointerTo(1, center + Offset(0f, gap / 2f))
+                move()
+            }
+            up(1)
+            repeat(8) { moveBy(0, Offset(-60f, 0f)) } // would arm the swipe if capture leaked
+            up(0)
+        }
+        compose.waitForIdle()
+
+        assertEquals(
+            "the one-finger tail of a pinch must never reach the page swipe",
+            0f,
+            swipeDragOffset.floatValue,
+            0.5f,
+        )
+    }
+
+    @Test
+    fun `the anchored settle animates through intermediate scales and is interruptible`() {
+        mount()
+        pinchOut()
+        compose.waitForIdle()
+        val zoomed = zoomState.scale.floatValue
+        assertTrue(zoomed > 1.5f)
+
+        compose.mainClock.autoAdvance = false
+        zoomState.settleAnchoredTo(1f, 540f, 900f, listState)
+        compose.mainClock.advanceTimeBy(80)
+        val midway = zoomState.scale.floatValue
+        assertTrue(
+            "the settle must be animating (midway=$midway, from=$zoomed)",
+            midway < zoomed - 0.05f && midway > 1f + 0.02f,
+        )
+        // A new pinch interrupts the animation (hypothesis 8): engage cancels the release job.
+        zoomState.engage(listState)
+        val frozen = zoomState.scale.floatValue
+        compose.mainClock.advanceTimeBy(300)
+        assertEquals("engage must freeze the settle", frozen, zoomState.scale.floatValue, 0.001f)
+        compose.mainClock.autoAdvance = true
+        compose.waitForIdle()
+    }
+
+    @Test
+    fun `a page key change resets the zoom and orphans no animation`() {
+        val key = mutableStateOf(1)
+        compose.setContent {
+            val scope = rememberCoroutineScope()
+            listState = remember { LazyListState() }
+            zoomState = rememberTopicZoomState(pageKey = key.value, animationScope = scope)
+            Box(Modifier.size(360.dp, 600.dp).testTag("zoom").topicMagnifier(zoomState, listState)) {
+                LazyColumn(state = listState) {
+                    items(count = 200) { i -> Text("post $i", Modifier.fillMaxWidth().height(48.dp)) }
+                }
+            }
+        }
+        pinchOut()
+        compose.waitForIdle()
+        assertTrue(zoomState.zoomed)
+
+        // Start a settle, then swap the page mid-animation: the NEW state must open at rest and
+        // the ORPHANED job must stop mutating the shared list (gate: scroll position frozen).
+        compose.mainClock.autoAdvance = false
+        zoomState.settleAnchoredTo(1f, 540f, 900f, listState)
+        compose.mainClock.advanceTimeBy(60)
+        key.value = 2
+        compose.mainClock.advanceTimeBy(32)
+        compose.waitForIdle()
+        val itemAfterSwap = listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset
+        compose.mainClock.advanceTimeBy(400)
+        compose.waitForIdle()
+        compose.mainClock.autoAdvance = true
+
+        assertEquals("the new page's state must open at 1x", 1f, zoomState.scale.floatValue, 0.001f)
+        assertEquals("panX must open at rest", 0f, zoomState.panX.floatValue, 0.001f)
+        assertEquals(
+            "the orphaned settle must stop scrolling the list after the key change",
+            itemAfterSwap,
+            listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset,
+        )
+    }
+
+    @Test
+    fun `one finger pan while zoomed scrolls the real list and bounds panX`() {
+        mount()
+        pinchOut()
+        compose.waitForIdle()
+        val itemBefore = listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset
+
+        compose.onNodeWithTag("zoom").performTouchInput {
+            down(0, center)
+            repeat(8) { moveBy(0, Offset(0f, -80f)) } // pan up = content up = list scrolls forward
+            up(0)
+        }
+        compose.waitForIdle()
+
+        val itemAfter = listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset
+        assertNotEquals("the vertical pan must drive the REAL list scroll", itemBefore, itemAfter)
+        val scale = zoomState.scale.floatValue
+        val panX = zoomState.panX.floatValue
+        assertTrue("panX must stay bounded", panX <= 0f && panX >= 1080f * (1f - scale) - 1f)
+    }
+}


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Étape finale du chantier #182-A : la loupe éphémère (esprit RF1) en production, portée depuis le POC GO (#935, 3 relevés, matrices émulateur + S10e 100 % vertes en release/R8).

**4 commits lisibles** (stratégie du cadrage) :
1. Reprise mécanique du câblage POC (7 fixes terrain/gates préservés à l'identique).
2. Durcissements du cadrage Sol : arrêt de fling séquencé (buffer de deltas — `stopScroll` ne peut pas suspendre dans le scope restreint du geste), clé d'état = identité complète `(cat, post, page)`, annulation des jobs orphelins à la dispose, KDoc dé-contradictoire, chip localisé/48 dp.
3. **Matrice instrumentée** : `TopicZoomGestureTest`, 10 tests Compose (pinch/bornes, snap exact, 3e pointeur participant, taps inertes + récupération, swipe armé annulé, swipe intact à 1×, capture tenue, settle observé mi-animation et interruptible, changement de clé sans mutation orpheline, pan = vrai scroll).
4. Fixes de la validation neutre gpt-5.5 (firstOrNull, floats parqués au cancel sans repreneur, Role.Button).

**Gates** : cadrage Sol GO conditionnel (tous les bloquants traités) · validation neutre **gpt-5.5** (validateur distinct des deux auteurs) : 2 fixes appliqués + notes actées · re-banc S10e du build de PROD : smoke pinch ✓, L2 pinch-pendant-scroll **20/20** — L6/L7 en cours sur le build final, résultats en commentaire avant merge.

**Différé tracé** : #942 (retransfert panY→scroll au contenu grandissant, repro exigée). Annonce du mode replié sur le fil DEV **avant** la release 0.30.0 (§7.5).

closes #937 · part of #182

- [x] Cadrage + gates croisés Sol · validation neutre gpt-5.5 · canonique complète verte

🤖 Generated with [Claude Code](https://claude.com/claude-code)