### PR TITLE
fix(settings): version honnête dans À propos pour les builds debug sideloadés

### DIFF
--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsAccountAboutScreen.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsAccountAboutScreen.kt
@@ -70,7 +70,15 @@ fun SettingsAccountAboutScreen(
             HorizontalDivider()
             RedfaceSettingsSection(stringResource(R.string.settings_about_version))
             Text(
-                text = stringResource(R.string.settings_about_version_value, versionName, versionCode),
+                // Sideloaded debug builds (versionName stamped `+debug.<sha>`) have NO ship build
+                // number — the app-v ledger stamps releases only, and the literal versionCode is a
+                // CD safety floor (72), not a build identity. Showing « (build 72) » there misled
+                // testers ; the SHA-stamped versionName alone is the honest identity.
+                text = if (versionName.contains("+debug.")) {
+                    versionName
+                } else {
+                    stringResource(R.string.settings_about_version_value, versionName, versionCode)
+                },
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Le « (build 72) » affiché dans À propos sur un build debug sideloadé est le plancher CD, pas une identité de build — il a induit le testeur en erreur pendant le dogfood #935. Le versionName estampillé SHA (`+debug.<sha>`) s'affiche désormais seul sur ces builds ; l'affichage release est inchangé. Sorti du diff #937 sur demande du cadrage (sans rapport).

🤖 Generated with [Claude Code](https://claude.com/claude-code)