### PR TITLE
chore(release): 0.30.0 — pinch-to-zoom (loupe globale #182-A)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,15 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.30.0` — `internal` (dev) — 2026-07-15
+
+Chantier pinch-to-zoom #182 (option A) — POC #935 GO (3 relevés, matrices émulateur + S10e), durcissement #936, production #937.
+
+- **Loupe globale de lecture** : pinch-to-zoom graphique éphémère de la page topic (esprit RF1) — plafond 2,5×, rubber-band saturant, pan 1 doigt (Y = vrai scroll + complément borné au bord bas), chip « 1× », reset au changement de page/sujet (#182, #935, #937).
+- Pendant le zoom : swipe de page, pull-to-refresh, double-tap refresh et sélection suspendus ; **taps/appuis longs inertes (mode replié annoncé sur le fil DEV)** — dézoomer pour interagir.
+- `topicPageSwipe` : annulation multi-touch native (2e doigt pendant un drag non commité = spring-back, jamais de navigation) (#936).
+- 32 tests ajoutés (maths de mapping, matrice de gestes, multi-touch swipe) ; gates croisés Sol/gpt-5.5/review Claude indépendante.
+
 ## `0.29.2` — `internal` (dev) — 2026-07-13
 
 **Batch autonome de l'après-midi** (5 chantiers, gates croisés Claude Fable 5 ↔ GPT 5.6 Sol : deux fixes codés par Sol et gatés par Claude, trois l'inverse).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.29.2"
+        versionName = "0.30.0"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,6 +1,5 @@
-Redface 2 v0.29.2 — dev.
+Redface 2 v0.30.0 — dev.
 
-- Search: category tabs no longer vanish after switching categories.
-- Editing: Edit/Delete come back on your own posts when your HFR profile hides the toolbar.
-- Reading: blank-line spacing now matches the website rendering exactly.
-- Editor: the "Contenu BBCode" label is never truncated anymore, and the smiley panel now uses ~3/4 of the screen.
+- Pinch-to-zoom: global reading magnifier in topics (RF1 spirit) — pinch to zoom, one finger to pan, 1x button to reset.
+- While zoomed: read-only (taps inert), zoom out to interact — details on the DEV thread.
+- Page swipe hardened against multi-touch.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,6 +1,5 @@
-Redface 2 v0.29.2 — dev.
+Redface 2 v0.30.0 — dev.
 
-- Recherche : les onglets de catégories ne disparaissent plus après un changement de catégorie.
-- Édition : Modifier/Supprimer réapparaissent sur vos propres posts si votre profil HFR masque les outils.
-- Lecture : l'espacement des lignes vides suit désormais exactement le rendu du site web.
-- Éditeur : le libellé « Contenu BBCode » n'est plus tronqué, et le panneau smileys occupe ~3/4 de l'écran.
+- Pinch-to-zoom : loupe globale de lecture dans les sujets (esprit RF1) — pincez pour zoomer, un doigt pour naviguer, bouton 1x pour revenir.
+- Pendant le zoom : lecture seule (taps inactifs), dézoomez pour interagir — détails sur le fil DEV.
+- Swipe de page durci contre le multi-touch.


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Bump 0.30.0 (politique A : nouveau chantier = mineur) + changelog app + whatsnew fr/en (garde freshness verte en local). Embarque : loupe #937 (+ #935/#936), fix #913 s'il n'était pas encore releasé est déjà dans 0.28.1 — cette release = le chantier pinch complet depuis 0.29.2. Annonce du mode replié DÉJÀ postée sur le fil DEV (§7.5). Dispatch `channel=dev --ref dev` après merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)