### PR TITLE
feat(topic): loupe v1.1 — plafond 3×, glisse verticale amortie, fix citations dépliées (#946)

### DIFF
--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -1166,10 +1166,11 @@ internal fun TopicContent(
                         // is provided to the post renderers so QuoteBlock masks a citation OF a
                         // blocked author. Scoped to the reading list only — the quick-reply sheet
                         // and editor previews (outside this provider) keep the empty default.
+                        // #946 — LocalTopicZoomed is deliberately NOT provided here any more :
+                        // its only consumer was the `selectable` flip, whose structural swap
+                        // destroyed the posts' saveable state on every zoom engage.
                         CompositionLocalProvider(
                             LocalBlockedQuoteAuthors provides mode.blockedQuoteAuthors,
-                            // POC #182 — suspends text selection in the post cards while zoomed.
-                            LocalTopicZoomed provides isZoomed,
                         ) {
                             TopicLoadedContent(
                                 state = state,
@@ -2792,9 +2793,13 @@ internal fun TopicPostCard(
                 CompositionLocalProvider(LocalPostImageActions provides imageActions) {
                     PostRenderer(
                         content = post.content,
-                        // POC #182 — selection is suspended while the magnifier is engaged (>1×);
-                        // topic posts are selectable at rest (#281).
-                        selectable = !LocalTopicZoomed.current,
+                        // #946 — `selectable` must NOT depend on the zoom: flipping it swaps the
+                        // SelectionContainer in/out of the tree, which STRUCTURALLY recreates the
+                        // whole post subtree and throws away every rememberSaveable below it (the
+                        // expanded long quotes collapsed on pinch, proven by the field logs and
+                        // TopicZoomQuoteFoldTest). Selection stays inert at >1× anyway: the
+                        // magnifier consumes the down (replied mode), no selection can start.
+                        selectable = true,
                         onGoToCitedPost = onGoToCitedPost,
                         mediaRefreshGeneration = mediaRefreshGeneration,
                     )

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoom.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoom.kt
@@ -1,6 +1,9 @@
 package fr.forumhfr.redface2.feature.topic
 
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationState
+import androidx.compose.animation.core.animateDecay
+import androidx.compose.animation.core.exponentialDecay
 import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.gestures.awaitEachGesture
@@ -16,10 +19,12 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.input.pointer.AwaitPointerEventScope
 import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.util.VelocityTracker
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -36,6 +41,18 @@ import kotlinx.coroutines.launch
 // reset on page AND topic change (state keyed on the full route identity).
 
 private const val ZOOM_SNAP_MILLIS = 200
+
+// v1.1 damped Y fling (community feedback on 0.30.0 : the zoomed pan felt « collant »). STRONG
+// friction — the sold contract is « a quick, bounded glide », deliberately shorter than a list
+// fling ; XaTriX pinned the axis (Y only : the X range is ~1.5 screens at 3×, a glide there
+// would just slam the bound). Values from the Sol framing, dp-based (density-independent).
+private const val FLING_FRICTION_MULTIPLIER = 3f
+private val FLING_MIN_VELOCITY = 500.dp
+private val FLING_MAX_VELOCITY = 4000.dp
+private val FLING_STOP_VELOCITY = 10.dp
+
+/** Frames of ~zero EFFECTIVE displacement (list + panY both saturated) before the decay stops. */
+private const val FLING_BLOCKED_FRAMES = 2
 
 /**
  * #182 — true while the reader is magnified (> 1×). NO LONGER wired to the `selectable` seam :
@@ -151,32 +168,75 @@ internal class TopicZoomState(private val animationScope: CoroutineScope) {
      * edge). Downward: panY unwinds back to 0 FIRST, then the list scrolls — panY is never left
      * engaged while scroll headroom exists in the visible direction.
      */
-    fun moveContentUp(deltaScreenPx: Float, listState: LazyListState) {
+    /** Returns the EFFECTIVE screen displacement (list + panY) — the fling's blocked detector. */
+    fun moveContentUp(deltaScreenPx: Float, listState: LazyListState): Float {
         // Fling stop still in flight : buffer instead of racing it (see [engage]).
         val stop = stopFlingJob
         if (stop != null && !stop.isCompleted) {
             pendingDeltaScreenPx += deltaScreenPx
-            return
+            return 0f
         }
         val delta = deltaScreenPx + pendingDeltaScreenPx
         pendingDeltaScreenPx = 0f
-        applyContentDelta(delta, listState)
+        return applyContentDelta(delta, listState)
     }
 
-    private fun applyContentDelta(deltaScreenPx: Float, listState: LazyListState) {
+    private fun applyContentDelta(deltaScreenPx: Float, listState: LazyListState): Float {
         // Delegates to the PURE TopicZoomMath vertical distribution (review finding : the tested
         // functions must be the ones the gesture executes — no hand-inlined twin).
         val s = scale.floatValue
-        if (deltaScreenPx >= 0f) {
+        val panYBefore = panY.floatValue
+        return if (deltaScreenPx >= 0f) {
             val consumed = listState.dispatchRawDelta(upwardListRequestViewportPx(deltaScreenPx, s))
             panY.floatValue =
                 upwardPanYAfterScroll(deltaScreenPx, consumed, panY.floatValue, s, viewportHeightPx)
+            consumed * s + (panYBefore - panY.floatValue)
         } else {
             val distribution =
                 downwardDistribution(deltaScreenPx, panY.floatValue, s, viewportHeightPx)
             panY.floatValue = distribution.panYNew
+            var consumedViewport = 0f
             if (distribution.listRequestViewportPx != 0f) {
-                listState.dispatchRawDelta(distribution.listRequestViewportPx)
+                consumedViewport = listState.dispatchRawDelta(distribution.listRequestViewportPx)
+            }
+            consumedViewport * s + (panYBefore - panY.floatValue)
+        }
+    }
+
+    /**
+     * v1.1 — damped vertical glide after a PAN-ONLY gesture (never after a pinch : hadPinch is
+     * latched in the gesture, Sol framing). Sequenced AFTER the engage-time stopScroll (join) so
+     * the decay is the only scroll producer ; stops early after [FLING_BLOCKED_FRAMES] frames of
+     * ~zero effective displacement (both bounds saturated). Interruption : engage() and the reset
+     * chip both cancel [releaseJob] — one cosmetic decay frame may land before the cancellation
+     * takes effect (main-thread sequencing), harmless because every mutation stays bounded.
+     */
+    fun startFling(
+        velocityYPx: Float,
+        stopVelocityPx: Float,
+        listState: LazyListState,
+    ) {
+        releaseJob?.cancel()
+        releaseJob = animationScope.launch {
+            stopFlingJob?.join()
+            var previous = 0f
+            var blockedFrames = 0
+            AnimationState(initialValue = 0f, initialVelocity = velocityYPx).animateDecay(
+                exponentialDecay(
+                    frictionMultiplier = FLING_FRICTION_MULTIPLIER,
+                    absVelocityThreshold = stopVelocityPx,
+                ),
+            ) {
+                val dy = value - previous
+                previous = value
+                // Finger semantics : the glide continues the finger, moveContentUp(-dy) like the
+                // pan frames (moveContentUp already distributes and divides by the scale).
+                val effective = moveContentUp(-dy, listState)
+                if (kotlin.math.abs(effective) < 0.5f && kotlin.math.abs(dy) >= 0.5f) {
+                    if (++blockedFrames >= FLING_BLOCKED_FRAMES) cancelAnimation()
+                } else {
+                    blockedFrames = 0
+                }
             }
         }
     }
@@ -264,18 +324,43 @@ internal fun Modifier.topicMagnifier(
         if (state.zoomed) firstDown.consume()
         state.viewportWidthPx = size.width.toFloat()
         state.viewportHeightPx = size.height.toFloat()
-        val engaged = trackMagnifierGesture(state, listState)
+        val tracking = MagnifierGestureTracking()
+        val engaged = trackMagnifierGesture(state, listState, tracking)
         state.releaseGesture()
         if (!engaged) return@awaitEachGesture
-        // Release: snap near-rest scales back to 1×, cap rubber-banded ones — ANCHORED on the last
-        // gesture position so the settle never jumps (panX converges into [0,0] on a snap to 1×).
-        state.settleAnchoredTo(
-            targetScale = resolveScaleOnRelease(state.scale.floatValue),
-            anchorX = state.lastAnchorX,
-            anchorY = state.lastAnchorY,
-            listState = listState,
-        )
+        val settledScale = resolveScaleOnRelease(state.scale.floatValue)
+        if (settledScale != state.scale.floatValue) {
+            // Snap near-rest scales back to 1×, cap rubber-banded ones — ANCHORED on the last
+            // gesture position so the settle never jumps (panX converges into [0,0] at 1×).
+            state.settleAnchoredTo(
+                targetScale = settledScale,
+                anchorX = state.lastAnchorX,
+                anchorY = state.lastAnchorY,
+                listState = listState,
+            )
+        } else if (state.zoomed && !tracking.hadPinch) {
+            // v1.1 — damped glide, PAN-ONLY gestures (Sol framing : a mixed pinch→pan gesture is
+            // latched out — a fling right after a scale change is the RF1 « sucette » feel).
+            val velocityY = tracking.velocityTracker.calculateVelocity().y
+            val minPx = FLING_MIN_VELOCITY.toPx()
+            val maxPx = FLING_MAX_VELOCITY.toPx()
+            if (kotlin.math.abs(velocityY) >= minPx) {
+                state.startFling(
+                    velocityYPx = velocityY.coerceIn(-maxPx, maxPx),
+                    stopVelocityPx = FLING_STOP_VELOCITY.toPx(),
+                    listState = listState,
+                )
+            }
+        }
     }
+}
+
+/** Per-gesture tracking for the release arbitration (settle vs damped glide). */
+private class MagnifierGestureTracking {
+    val velocityTracker = VelocityTracker()
+
+    /** Latched at the first two-pointer frame — a gesture that ever pinched never flings (Sol). */
+    var hadPinch = false
 }
 
 /**
@@ -288,6 +373,7 @@ internal fun Modifier.topicMagnifier(
 private suspend fun AwaitPointerEventScope.trackMagnifierGesture(
     state: TopicZoomState,
     listState: LazyListState,
+    tracking: MagnifierGestureTracking,
 ): Boolean {
     var engaged = false
     while (true) {
@@ -295,7 +381,7 @@ private suspend fun AwaitPointerEventScope.trackMagnifierGesture(
         val released = event.changes.none { it.pressed }
         if (released && engaged) event.changes.forEach { it.consume() }
         if (released) return engaged
-        engaged = handleMagnifierFrame(state, listState, event, engaged)
+        engaged = handleMagnifierFrame(state, listState, event, engaged, tracking)
     }
 }
 
@@ -313,15 +399,21 @@ private fun AwaitPointerEventScope.handleMagnifierFrame(
     listState: LazyListState,
     event: PointerEvent,
     wasEngaged: Boolean,
+    tracking: MagnifierGestureTracking,
 ): Boolean {
     val pressed = event.changes.count { it.pressed }
     val engaging = pressed >= 2 || wasEngaged || state.zoomed
     if (!engaging) return false
     if (!wasEngaged) state.engage(listState)
     if (pressed >= 2) {
+        if (!tracking.hadPinch) {
+            // Latch + reset : no velocity inherited from before/inside the pinch (Sol framing).
+            tracking.hadPinch = true
+            tracking.velocityTracker.resetTracking()
+        }
         applyPinchFrame(state, listState, event, size.width.toFloat())
     } else {
-        applyPanFrame(state, listState, event, size.width.toFloat())
+        applyPanFrame(state, listState, event, size.width.toFloat(), tracking)
     }
     event.changes.forEach { it.consume() }
     return true
@@ -333,10 +425,12 @@ private fun applyPanFrame(
     listState: LazyListState,
     event: PointerEvent,
     widthPx: Float,
+    tracking: MagnifierGestureTracking,
 ) {
     // firstOrNull (validation 5.5) : a transient frame where every pointer just lifted must not
     // crash — the release branch of the loop handles it on the next event.
     val change = event.changes.firstOrNull { it.pressed } ?: return
+    tracking.velocityTracker.addPosition(change.uptimeMillis, change.position)
     val delta = change.position - change.previousPosition
     val scale = state.scale.floatValue
     state.panX.floatValue = panStep(state.panX.floatValue, delta.x, scale, widthPx)

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoom.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoom.kt
@@ -38,8 +38,11 @@ import kotlinx.coroutines.launch
 private const val ZOOM_SNAP_MILLIS = 200
 
 /**
- * POC #182 — true while the reader is magnified (> 1×). Read by the post cards to suspend text
- * selection (the `selectable` seam) without threading a parameter through the whole call chain.
+ * #182 — true while the reader is magnified (> 1×). NO LONGER wired to the `selectable` seam :
+ * flipping `selectable` with the zoom swapped the SelectionContainer in/out of the tree, which
+ * structurally recreated the post subtree and threw away every rememberSaveable below it (#946 —
+ * expanded long quotes collapsed on pinch). Selection stays inert at >1× through the replied
+ * mode (the magnifier consumes the down). Kept for tests and potential non-structural consumers.
  */
 internal val LocalTopicZoomed = compositionLocalOf { false }
 

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoomMath.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoomMath.kt
@@ -4,7 +4,10 @@ import kotlin.math.atanh
 import kotlin.math.tanh
 
 internal const val MIN_ZOOM_SCALE = 1f
-internal const val MAX_ZOOM_SCALE = 2.5f
+// 2.5f at first delivery ; raised to 3f on unanimous community feedback (0.30.0, DEV
+// thread — thibw/Deadlock/Dintr-un lemn/nicko/tinc). Beyond 3x the 1024 px inline decode cap
+// shows (blur) : deeper inspection is the image viewer's job (#182-C), not the magnifier's.
+internal const val MAX_ZOOM_SCALE = 3f
 internal const val ZOOM_RELEASE_SNAP_THRESHOLD = 1.03f
 
 /** Maximum displayed overshoot past [MAX_ZOOM_SCALE] while the fingers keep squeezing. */

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoomGestureTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoomGestureTest.kt
@@ -399,4 +399,85 @@ class TopicZoomGestureTest {
         val panX = zoomState.panX.floatValue
         assertTrue("panX must stay bounded", panX <= 0f && panX >= 1080f * (1f - scale) - 1f)
     }
+
+    @Test
+    fun `a fast zoomed pan release glides on after the finger lifts`() {
+        mount()
+        pinchOut()
+        compose.waitForIdle()
+        // Fast one-finger pan up : high release velocity.
+        compose.onNodeWithTag("zoom").performTouchInput {
+            down(0, center + Offset(0f, 300f))
+            repeat(6) { moveBy(0, Offset(0f, -90f)) }
+            up(0)
+        }
+        val atRelease = listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset
+        compose.mainClock.advanceTimeBy(600)
+        compose.waitForIdle()
+        val afterDecay = listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset
+
+        assertNotEquals("the damped glide must keep scrolling after the lift", atRelease, afterDecay)
+        val settled = afterDecay
+        compose.mainClock.advanceTimeBy(1500)
+        compose.waitForIdle()
+        assertEquals(
+            "the strong friction must have stopped the glide well within ~600ms",
+            settled,
+            listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset,
+        )
+    }
+
+    @Test
+    fun `a gesture that pinched never flings on release`() {
+        mount()
+        compose.onNodeWithTag("zoom").performTouchInput {
+            down(0, center - Offset(0f, 150f))
+            down(1, center + Offset(0f, 150f))
+            repeat(6) { i ->
+                val gap = 300f + 300f * (i + 1) / 6
+                updatePointerTo(0, center - Offset(0f, gap / 2f))
+                updatePointerTo(1, center + Offset(0f, gap / 2f))
+                move()
+            }
+            up(1)
+            // Same gesture continues as a FAST pan : hadPinch is latched, no fling allowed.
+            repeat(6) { moveBy(0, Offset(0f, -90f)) }
+            up(0)
+        }
+        compose.waitForIdle()
+        val atRelease = listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset
+        compose.mainClock.advanceTimeBy(600)
+        compose.waitForIdle()
+
+        assertEquals(
+            "a mixed pinch-pan gesture must stop dead at the lift (no RF1 sucette)",
+            atRelease,
+            listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset,
+        )
+    }
+
+    @Test
+    fun `a slow zoomed pan release does not fling`() {
+        mount()
+        pinchOut()
+        compose.waitForIdle()
+        compose.onNodeWithTag("zoom").performTouchInput {
+            down(0, center + Offset(0f, 300f))
+            repeat(6) {
+                advanceEventTime(120)
+                moveBy(0, Offset(0f, -30f))
+            }
+            up(0)
+        }
+        compose.waitForIdle()
+        val atRelease = listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset
+        compose.mainClock.advanceTimeBy(600)
+        compose.waitForIdle()
+
+        assertEquals(
+            "below the velocity threshold the pan must stop with the finger",
+            atRelease,
+            listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset,
+        )
+    }
 }

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoomMathTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoomMathTest.kt
@@ -10,7 +10,7 @@ class TopicZoomMathTest {
 
     @Test
     fun `pinch keeps the content under the centroid fixed on screen`() {
-        val rubberedScale = clampScaleDuringPinch(raw = 3f)
+        val rubberedScale = clampScaleDuringPinch(raw = 3.5f)
         val cases = listOf(
             PinchCase(
                 label = "zoom in from rest",
@@ -139,13 +139,13 @@ class TopicZoomMathTest {
         assertTrue(justPastJoin > atJoin)
         assertEquals(atJoin, justPastJoin, 0.00011f)
 
-        val rawScales = listOf(2.5f, 2.6f, 3f, 4f, 10f)
+        val rawScales = listOf(3f, 3.1f, 3.5f, 4f, 10f)
         val displayScales = rawScales.map(::clampScaleDuringPinch)
         displayScales.zipWithNext().forEach { (first, second) ->
             assertTrue("rubber band must stay monotone: $first then $second", second > first)
         }
-        assertTrue(clampScaleDuringPinch(raw = 3f) > MAX_ZOOM_SCALE)
-        assertTrue(clampScaleDuringPinch(raw = 3f) < 3f)
+        assertTrue(clampScaleDuringPinch(raw = 3.5f) > MAX_ZOOM_SCALE)
+        assertTrue(clampScaleDuringPinch(raw = 3.5f) < 3.5f)
     }
 
     @Test
@@ -154,13 +154,13 @@ class TopicZoomMathTest {
         assertEquals(1f, resolveScaleOnRelease(gestureScale = 1.03f), TOLERANCE)
         assertEquals(1.0301f, resolveScaleOnRelease(gestureScale = 1.0301f), TOLERANCE)
         assertEquals(1.8f, resolveScaleOnRelease(gestureScale = 1.8f), TOLERANCE)
-        assertEquals(2.5f, resolveScaleOnRelease(gestureScale = 2.5f), TOLERANCE)
-        assertEquals(2.5f, resolveScaleOnRelease(gestureScale = 2.8f), TOLERANCE)
+        assertEquals(3f, resolveScaleOnRelease(gestureScale = 3f), TOLERANCE)
+        assertEquals(3f, resolveScaleOnRelease(gestureScale = 3.4f), TOLERANCE)
     }
 
     @Test
     fun `incremental factors remain directional in the rubber band`() {
-        val scaleOld = clampScaleDuringPinch(raw = 3f)
+        val scaleOld = clampScaleDuringPinch(raw = 3.5f)
         val rubbered = ZoomTransform(scale = scaleOld, panX = -500f)
         val noOp = pinchStep(rubbered, 400f, 700f, 1f, 1000f)
         val zoomIn = pinchStep(rubbered, 400f, 700f, 1.01f, 1000f)

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoomQuoteFoldTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoomQuoteFoldTest.kt
@@ -9,7 +9,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoomQuoteFoldTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoomQuoteFoldTest.kt
@@ -50,7 +50,9 @@ class TopicZoomQuoteFoldTest {
     private lateinit var zoomState: TopicZoomState
 
     private fun longQuoteContent(): PostContent {
-        val longText = buildString { repeat(30) { append("Ligne de citation numéro $it assez longue pour dépasser le seuil. ") } }
+        val longText = buildString {
+            repeat(30) { append("Ligne de citation numéro $it assez longue pour dépasser le seuil. ") }
+        }
         return PostContent(
             blocks = listOf(
                 PostBlock.Quote(

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoomQuoteFoldTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicZoomQuoteFoldTest.kt
@@ -1,0 +1,130 @@
+package fr.forumhfr.redface2.feature.topic
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.unit.dp
+import fr.forumhfr.redface2.core.model.PostBlock
+import fr.forumhfr.redface2.core.model.PostContent
+import fr.forumhfr.redface2.core.model.PostInline
+import fr.forumhfr.redface2.core.ui.RedfaceTheme
+import fr.forumhfr.redface2.core.ui.post.PostRenderer
+import fr.forumhfr.redface2.core.ui.theme.LocalFoldLongQuotes
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * #946 — pinching on an EXPANDED long quote must not fold it back (tinc, DEV thread, v240).
+ * Reproduces the field scenario: a real [PostRenderer] long quote inside the magnifier harness,
+ * expanded by tap, then a pinch centred on it.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h780dp-xxhdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class TopicZoomQuoteFoldTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private lateinit var zoomState: TopicZoomState
+
+    private fun longQuoteContent(): PostContent {
+        val longText = buildString { repeat(30) { append("Ligne de citation numéro $it assez longue pour dépasser le seuil. ") } }
+        return PostContent(
+            blocks = listOf(
+                PostBlock.Quote(
+                    author = "tinc",
+                    numreponse = 42,
+                    page = 1,
+                    content = PostContent(
+                        blocks = listOf(
+                            PostBlock.Paragraph(inlines = listOf(PostInline.Text(longText))),
+                        ),
+                    ),
+                ),
+                PostBlock.Paragraph(inlines = listOf(PostInline.Text("réponse au-dessous"))),
+            ),
+        )
+    }
+
+    @Test
+    fun `pinching on an expanded long quote keeps it expanded`() {
+        compose.setContent {
+            RedfaceTheme {
+                CompositionLocalProvider(LocalFoldLongQuotes provides true) {
+                    val scope = rememberCoroutineScope()
+                    val listState = remember { LazyListState() }
+                    zoomState = rememberTopicZoomState(pageKey = 1, animationScope = scope)
+                    val isZoomed by remember(zoomState) { androidx.compose.runtime.derivedStateOf { zoomState.zoomed } }
+                    CompositionLocalProvider(LocalTopicZoomed provides isZoomed) {
+                    Box(
+                        Modifier
+                            .size(360.dp, 600.dp)
+                            .testTag("zoom")
+                            .topicMagnifier(zoomState, listState),
+                    ) {
+                        LazyColumn(state = listState) {
+                            item {
+                                // Parité TopicScreen post-#946 : selectable est FIXE. Le flip
+                                // zoom-dépendant était LE mécanisme du bug (swap structurel du
+                                // SelectionContainer -> rememberSaveable jeté) — reproduit ROUGE
+                                // avec `selectable = !LocalTopicZoomed.current` avant le fix.
+                                PostRenderer(
+                                    content = longQuoteContent(),
+                                    selectable = true,
+                                )
+                            }
+                            items(count = 50) { i ->
+                                Text("post $i", Modifier.fillMaxWidth())
+                            }
+                        }
+                    }
+                    }
+                }
+            }
+        }
+        // Expand the folded long quote (the frame toggles on tap).
+        compose.onNodeWithText("Déplier", substring = true).performClick()
+        compose.waitForIdle()
+        compose.onNodeWithText("Replier", substring = true).assertExists()
+
+        // Pinch centred on the expanded quote (both fingers on it) — field scenario.
+        compose.onNodeWithTag("zoom").performTouchInput {
+            down(0, center - Offset(0f, 150f))
+            down(1, center + Offset(0f, 150f))
+            repeat(10) { i ->
+                val gap = 300f + 450f * (i + 1) / 10
+                updatePointerTo(0, center - Offset(0f, gap / 2f))
+                updatePointerTo(1, center + Offset(0f, gap / 2f))
+                move()
+            }
+            up(0)
+            up(1)
+        }
+        compose.waitForIdle()
+
+        assertTrue("the pinch must engage the zoom", zoomState.scale.floatValue > 1.2f)
+        compose.onNodeWithText("Replier", substring = true).assertExists()
+    }
+}


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Le lot de retours 0.30.0 (fil DEV), cadré et gaté Sol :

- **Fix #946** (tinc) : pincer sur une citation dépliée la repliait. Cause **capturée par instrumentation device** : le flip `selectable` au zoom swappait le SelectionContainer → recréation structurelle du sous-arbre → tous les `rememberSaveable` jetés. Le recyclage a été innocenté (aller-retour 4 écrans : état conservé). Fix : `selectable` constant (redondant avec le mode replié qui consomme le down). Repro JVM rouge-avant/verte-après sur le vrai `FoldableQuoteBlock` ; re-validé au doigt scripté sur S10e.
- **Plafond 3×** (retour unanime) — au-delà, le cap de décodage inline 1024 px se voit : la suite c'est le viewer (#182-C).
- **Glisse verticale amortie** après un pan zoomé pur (thibw/styx42/tinc ; axe Y acté par XaTriX sur le fil) : cadrage Sol appliqué verbatim — verrou `hadPinch` (un geste qui a pincé ne glisse jamais : le tueur de « sucette RF1 »), friction forte (decay exponentiel ×3), seuils en dp, arrêt anticipé sur déplacement effectif nul. 3 tests de gestes dédiés.

**Gates** : cadrage fling Sol GO → implémentation → gate diff Sol **GO release** (1 nit appliqué) · 36 tests du chantier verts (13 gestes + 16 maths + 1 fold + 6 swipe) · smoke S10e release/R8 : zoom 3× ✓, pan ✓, fix #946 ✓ (le glide au doigt = verdict testeurs, réglage subjectif de friction).

closes #946 · part of #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)