### PR TITLE
chore(release): 0.30.1 — loupe v1.1 (3×, glisse amortie, fix #946)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,14 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.30.1` — `internal` (dev) — 2026-07-15
+
+Lot v1.1 de la loupe — retours communautaires 0.30.0 (fil DEV), même journée.
+
+- Loupe : plafond de zoom relevé à **3×** (demande unanime) ; au-delà, place au futur viewer d'images.
+- Loupe : **glisse verticale amortie** après un déplacement zoomé (décélération rapide, bornée, jamais après un pincement — le « lancer en sucette » de RF1 est structurellement impossible) (#182).
+- Fix #946 : pincer sur une citation dépliée ne la replie plus (le changement structurel du mode replié jetait l'état des citations).
+
 ## `0.30.0` — `internal` (dev) — 2026-07-15
 
 Chantier pinch-to-zoom #182 (option A) — POC #935 GO (3 relevés, matrices émulateur + S10e), durcissement #936, production #937.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.30.0"
+        versionName = "0.30.1"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,5 +1,4 @@
-Redface 2 v0.30.0 — dev.
+Redface 2 v0.30.1 — dev.
 
-- Pinch-to-zoom: global reading magnifier in topics (RF1 spirit) — pinch to zoom, one finger to pan, 1x button to reset.
-- While zoomed: read-only (taps inert), zoom out to interact — details on the DEV thread.
-- Page swipe hardened against multi-touch.
+- Magnifier: max zoom raised to 3x (unanimous request) and damped vertical glide while panning zoomed.
+- Pinching an expanded quote no longer folds it back.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,5 +1,4 @@
-Redface 2 v0.30.0 — dev.
+Redface 2 v0.30.1 — dev.
 
-- Pinch-to-zoom : loupe globale de lecture dans les sujets (esprit RF1) — pincez pour zoomer, un doigt pour naviguer, bouton 1x pour revenir.
-- Pendant le zoom : lecture seule (taps inactifs), dézoomez pour interagir — détails sur le fil DEV.
-- Swipe de page durci contre le multi-touch.
+- Loupe : zoom max relevé à 3x (demande unanime) et glisse verticale amortie au déplacement zoomé.
+- Pincer sur une citation dépliée ne la replie plus.


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaTriX)

Bump patch (politique A), changelog app, whatsnew fr/en (garde freshness verte en local). Dispatch `channel=dev --ref dev` après merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)