### PR TITLE
feat(editor): feuille de réponse rapide expérimentale, plein écran par défaut (#951)

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -16,6 +16,15 @@ Workflow (depuis #304, CD rev. 4) : le **`versionCode` n'est plus bumpé à la m
 
 ---
 
+## `0.32.0` — `internal` (dev) — 2026-07-15
+
+Décision produit #951 : la feuille de réponse rapide n'est pas correctement terminée.
+
+- Éditeur : la **feuille de réponse rapide passe en expérimental** (opt-in). Le défaut de
+  « Surface d'écriture » devient **« Toujours plein écran »** ; les deux presets feuille sont
+  étiquetés « (expérimental) » dans les réglages (pattern #805). Les utilisateurs qui avaient
+  déjà choisi un preset gardent leur choix.
+
 ## `0.31.0` — `internal` (dev) — 2026-07-15
 
 Premier lot du chantier couleurs #883 (arbitrage XaTriX sur la galerie V2 : la refonte

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
         // versionName is also surfaced in the app footer via BuildConfig.VERSION_NAME so
         // dogfood builds advertise their lineage to the user.
         versionCode = cliVersionCode ?: 72
-        versionName = "0.31.0"
+        versionName = "0.32.0"
 
         // Manifest placeholder so a side-by-side install (dogfood/preview overlay)
         // can override the launcher label without touching tracked manifest/strings.

--- a/app/src/main/play/whatsnew/whatsnew-en-US
+++ b/app/src/main/play/whatsnew/whatsnew-en-US
@@ -1,3 +1,3 @@
-Redface 2 v0.31.0 — dev.
+Redface 2 v0.32.0 — dev.
 
-- Yellow no more: the tertiary accent turns slate across every palette (anchored-post band, armed submit button, nested quotes).
+- The quick-reply sheet is now experimental (not feature-complete): reply and quote open the full-screen editor by default. The sheet stays available in Settings > Writing surface.

--- a/app/src/main/play/whatsnew/whatsnew-fr-FR
+++ b/app/src/main/play/whatsnew/whatsnew-fr-FR
@@ -1,3 +1,3 @@
-Redface 2 v0.31.0 — dev.
+Redface 2 v0.32.0 — dev.
 
-- Fini le jaune : l'accent tertiaire passe à l'ardoise sur toutes les palettes (bande du post ciblé, bouton d'envoi armé, citations imbriquées).
+- La feuille de réponse rapide passe en expérimental (pas finalisée) : répondre et citer ouvrent désormais l'éditeur plein écran par défaut. La feuille reste activable dans Réglages > Surface d'écriture.

--- a/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepository.kt
@@ -367,11 +367,11 @@ class DataStoreUserPreferencesRepository @Inject constructor(
 
     override fun observeWritingSurfacePreset(): Flow<WritingSurfacePreset> =
         dataStore.data
-            // Default SHEET (#806): the 0.25.1 behaviour — quick-reply sheet everywhere, with the
-            // 3+ multi-quote threshold escalating to the full-screen editor.
+            // Default FULL_EDITOR (#951): the quick-reply sheet is experimental opt-in — users
+            // who explicitly picked a sheet preset keep it (stored value wins over the default).
             .map(::readWritingSurfacePreset)
             .distinctUntilChanged()
-            .catch { emit(WritingSurfacePreset.SHEET) }
+            .catch { emit(WritingSurfacePreset.FULL_EDITOR) }
 
     override suspend fun setWritingSurfacePreset(preset: WritingSurfacePreset) {
         persist {
@@ -777,11 +777,11 @@ class DataStoreUserPreferencesRepository @Inject constructor(
             ?.let { stored -> runCatching { EditorImageInsert.valueOf(stored) }.getOrNull() }
             ?: EditorImageInsert.REDUCED
 
-    /** Reads [KEY_WRITING_SURFACE_PRESET] defensively; unknown / corrupt value → [WritingSurfacePreset.SHEET]. */
+    /** Reads [KEY_WRITING_SURFACE_PRESET] defensively; unknown / corrupt value → [WritingSurfacePreset.FULL_EDITOR]. */
     private fun readWritingSurfacePreset(prefs: Preferences): WritingSurfacePreset =
         prefs[KEY_WRITING_SURFACE_PRESET]
             ?.let { stored -> runCatching { WritingSurfacePreset.valueOf(stored) }.getOrNull() }
-            ?: WritingSurfacePreset.SHEET
+            ?: WritingSurfacePreset.FULL_EDITOR
 
     /**
      * Reads [KEY_DISPLAY_DENSITY] defensively (#287): an unknown / corrupt stored value (older

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/preferences/DataStoreUserPreferencesRepositoryTest.kt
@@ -1076,10 +1076,11 @@ class DataStoreUserPreferencesRepositoryTest {
     }
 
     @Test
-    fun `observeWritingSurfacePreset defaults to SHEET on an empty store`() = runTest(dispatcher) {
-        // #806 — SHEET is the default (the 0.25.1 behaviour), never the enum's first ordinal by chance.
+    fun `observeWritingSurfacePreset defaults to FULL_EDITOR on an empty store`() = runTest(dispatcher) {
+        // #951 — FULL_EDITOR is the default (the quick-reply sheet is experimental opt-in),
+        // never the enum's first ordinal by chance.
         repository.observeWritingSurfacePreset().test {
-            assertEquals(WritingSurfacePreset.SHEET, awaitItem())
+            assertEquals(WritingSurfacePreset.FULL_EDITOR, awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -1100,12 +1101,12 @@ class DataStoreUserPreferencesRepositoryTest {
     }
 
     @Test
-    fun `corrupt writing_surface_preset value falls back to SHEET instead of crashing`() = runTest(dispatcher) {
-        // An unknown value (older build / manual edit) must degrade to SHEET, not crash valueOf.
+    fun `corrupt writing_surface_preset value falls back to FULL_EDITOR instead of crashing`() = runTest(dispatcher) {
+        // An unknown value (older build / manual edit) must degrade to FULL_EDITOR, not crash valueOf.
         dataStore.edit { prefs -> prefs[stringPreferencesKey("writing_surface_preset")] = "HOLODECK" }
 
         repository.observeWritingSurfacePreset().test {
-            assertEquals(WritingSurfacePreset.SHEET, awaitItem())
+            assertEquals(WritingSurfacePreset.FULL_EDITOR, awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/fr/forumhfr/redface2/core/data/topic/TopicRepositoryImplTest.kt
@@ -651,7 +651,7 @@ class TopicRepositoryImplTest {
 
         // #806 — writing surface is irrelevant to TopicRepositoryImpl; stubbed at its default.
         override fun observeWritingSurfacePreset(): Flow<WritingSurfacePreset> =
-            MutableStateFlow(WritingSurfacePreset.SHEET)
+            MutableStateFlow(WritingSurfacePreset.FULL_EDITOR)
 
         override suspend fun setWritingSurfacePreset(preset: WritingSurfacePreset) = Unit
 

--- a/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
+++ b/core/domain/src/main/kotlin/fr/forumhfr/redface2/core/domain/preferences/UserPreferencesRepository.kt
@@ -252,15 +252,16 @@ interface UserPreferencesRepository {
 
     /**
      * #806 — which composition surface a write action in a topic opens (reply FAB, « Citer »,
-     * « Citer N »). Default [WritingSurfacePreset.SHEET] = the 0.25.1 behaviour exactly (quick-reply
-     * sheet everywhere, 3+ multi-quote escalating to the full-screen editor). The preset decides the
-     * surface only — quote RENDERING stays [observeQuoteCardsEnabled] (#805). A corrupt / unknown
-     * stored value degrades to the default. Observed by `:feature:topic` (decision at tap time, an
-     * open sheet is never migrated), chosen in Settings (« Édition et publication »).
+     * « Citer N »). Default [WritingSurfacePreset.FULL_EDITOR] since the quick-reply sheet moved
+     * to experimental status (#951) — the sheet presets stay available as opt-in. The preset
+     * decides the surface only — quote RENDERING stays [observeQuoteCardsEnabled] (#805). A
+     * corrupt / unknown stored value degrades to the default. Observed by `:feature:topic`
+     * (decision at tap time, an open sheet is never migrated), chosen in Settings
+     * (« Édition et publication »).
      */
     fun observeWritingSurfacePreset(): Flow<WritingSurfacePreset>
 
-    /** Persists [observeWritingSurfacePreset]. Default [WritingSurfacePreset.SHEET] until the first call. */
+    /** Persists [observeWritingSurfacePreset]. Default [WritingSurfacePreset.FULL_EDITOR] until the first call. */
     suspend fun setWritingSurfacePreset(preset: WritingSurfacePreset)
 
     /**

--- a/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/editor/WritingSurfacePreset.kt
+++ b/core/model/src/main/kotlin/fr/forumhfr/redface2/core/model/editor/WritingSurfacePreset.kt
@@ -11,15 +11,19 @@ package fr.forumhfr.redface2.core.model.editor
  */
 enum class WritingSurfacePreset {
     /**
-     * Default — the 0.25.1 behaviour, exactly: every write action opens the quick-reply sheet,
-     * except a multi-quote basket of 3+ cards which goes straight to the full-screen editor
-     * (the #604 lot 3 threshold, which guards THIS preset only).
+     * The 0.25.1 behaviour, exactly: every write action opens the quick-reply sheet, except a
+     * multi-quote basket of 3+ cards which goes straight to the full-screen editor (the #604
+     * lot 3 threshold, which guards THIS preset only). Experimental opt-in while the sheet is
+     * not feature-complete (#951).
      */
     SHEET,
 
     /** The sheet for plain replies; any citation (single « Citer » or « Citer N ») opens the full-screen editor. */
     SHEET_EXCEPT_QUOTES,
 
-    /** Every write action opens the full-screen editor; the quick-reply sheet never shows. */
+    /**
+     * Default — every write action opens the full-screen editor; the quick-reply sheet never
+     * shows. Became the default when the sheet moved to experimental status (#951).
+     */
     FULL_EDITOR,
 }

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/PostEditorViewModelTest.kt
@@ -2253,7 +2253,7 @@ class PostEditorViewModelTest {
 
         // #806 — the writing-surface preset routes taps in :feature:topic, not here; default stub.
         override fun observeWritingSurfacePreset(): Flow<WritingSurfacePreset> =
-            MutableStateFlow(WritingSurfacePreset.SHEET)
+            MutableStateFlow(WritingSurfacePreset.FULL_EDITOR)
 
         override suspend fun setWritingSurfacePreset(preset: WritingSurfacePreset) = Unit
 

--- a/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
+++ b/feature/editor/src/test/kotlin/fr/forumhfr/redface2/feature/editor/TopicFormViewModelTest.kt
@@ -1507,7 +1507,7 @@ class TopicFormViewModelTest {
 
         // #806 — the writing-surface preset routes taps in :feature:topic, not here; default stub.
         override fun observeWritingSurfacePreset(): Flow<WritingSurfacePreset> =
-            MutableStateFlow(WritingSurfacePreset.SHEET)
+            MutableStateFlow(WritingSurfacePreset.FULL_EDITOR)
 
         override suspend fun setWritingSurfacePreset(preset: WritingSurfacePreset) = Unit
 

--- a/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
+++ b/feature/settings/src/main/kotlin/fr/forumhfr/redface2/feature/settings/SettingsState.kt
@@ -185,9 +185,9 @@ data class SettingsState(
     val quoteCardsEnabledTouchedLocally: Boolean = false,
     // #806 — which surface a write action in a topic opens (sheet / sheet-except-quotes / full
     // editor). Enum, so the same bespoke optimistic-flip shape as [editorImageInsert]. Default
-    // SHEET (the 0.25.1 behaviour). Distinct from [quoteCardsEnabled], which governs the quote
-    // RENDERING inside whichever surface opens.
-    val writingSurfacePreset: WritingSurfacePreset = WritingSurfacePreset.SHEET,
+    // FULL_EDITOR since the quick-reply sheet is experimental opt-in (#951). Distinct from
+    // [quoteCardsEnabled], which governs the quote RENDERING inside whichever surface opens.
+    val writingSurfacePreset: WritingSurfacePreset = WritingSurfacePreset.FULL_EDITOR,
     val isUpdatingWritingSurfacePreset: Boolean = false,
     val writingSurfacePresetError: Boolean = false,
     val writingSurfacePresetTouchedLocally: Boolean = false,

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -355,14 +355,16 @@
     <string name="settings_confirm_before_posting_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
     <!-- #806 — surface d'écriture : quelle surface s'ouvre quand on répond ou cite depuis un sujet
          (feuille de réponse rapide ou éditeur plein écran). Le réglage choisit la SURFACE seulement ;
-         le rendu des citations (cartes ou BBCode) reste le réglage « Citations en cartes » ci-dessous. -->
+         le rendu des citations (cartes ou BBCode) reste le réglage « Citations en cartes » ci-dessous.
+         #951 — la feuille n'est pas finalisée : presets feuille étiquetés « (expérimental) »
+         (pattern #805), défaut = « Toujours plein écran ». -->
     <string name="settings_writing_surface_title">Surface d\'écriture</string>
-    <string name="settings_writing_surface_sheet">Toujours la feuille</string>
-    <string name="settings_writing_surface_sheet_description">Répondre et citer ouvrent la feuille de réponse rapide ; à partir de 3 citations, l\'éditeur plein écran prend le relais.</string>
-    <string name="settings_writing_surface_sheet_except_quotes">Feuille sauf citations</string>
-    <string name="settings_writing_surface_sheet_except_quotes_description">Répondre ouvre la feuille ; toute citation ouvre l\'éditeur plein écran.</string>
+    <string name="settings_writing_surface_sheet">Toujours la feuille (expérimental)</string>
+    <string name="settings_writing_surface_sheet_description">Expérimental : la feuille de réponse rapide n\'est pas finalisée. Répondre et citer l\'ouvrent ; à partir de 3 citations, l\'éditeur plein écran prend le relais.</string>
+    <string name="settings_writing_surface_sheet_except_quotes">Feuille sauf citations (expérimental)</string>
+    <string name="settings_writing_surface_sheet_except_quotes_description">Expérimental : la feuille de réponse rapide n\'est pas finalisée. Répondre l\'ouvre ; toute citation ouvre l\'éditeur plein écran.</string>
     <string name="settings_writing_surface_full_editor">Toujours plein écran</string>
-    <string name="settings_writing_surface_full_editor_description">Répondre et citer ouvrent directement l\'éditeur plein écran.</string>
+    <string name="settings_writing_surface_full_editor_description">Répondre et citer ouvrent directement l\'éditeur plein écran (défaut).</string>
     <string name="settings_writing_surface_persist_failed">Impossible de mémoriser ce réglage. Réessayez.</string>
     <!-- #805 — statut expérimental acté (arbitrage 11/07) : même pattern que settings_mp_sync_write_title. -->
     <string name="settings_quote_cards_title">Citations en cartes (expérimental)</string>

--- a/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/fr/forumhfr/redface2/feature/settings/SettingsViewModelTest.kt
@@ -1413,8 +1413,8 @@ class SettingsViewModelTest {
     fun `writingSurfacePreset re-syncs continuously from the persisted preference (#788)`() = runTest {
         val viewModel = newViewModel()
         assertEquals(
-            "#806 — SHEET is the default (the 0.25.1 behaviour)",
-            WritingSurfacePreset.SHEET,
+            "#951 — FULL_EDITOR is the default (the sheet is experimental opt-in)",
+            WritingSurfacePreset.FULL_EDITOR,
             viewModel.state.value.writingSurfacePreset,
         )
 
@@ -1441,11 +1441,11 @@ class SettingsViewModelTest {
         repository.failOnWritingSurfacePresetSet = true
         val viewModel = newViewModel()
 
-        viewModel.submit(SettingsIntent.SetWritingSurfacePreset(WritingSurfacePreset.FULL_EDITOR))
+        viewModel.submit(SettingsIntent.SetWritingSurfacePreset(WritingSurfacePreset.SHEET))
 
         assertEquals(
             "must revert to the previous value on failure",
-            WritingSurfacePreset.SHEET,
+            WritingSurfacePreset.FULL_EDITOR,
             viewModel.state.value.writingSurfacePreset,
         )
         assertFalse(viewModel.state.value.isUpdatingWritingSurfacePreset)
@@ -2134,7 +2134,8 @@ class SettingsViewModelTest {
         }
 
         // #806 — writing-surface preset. Same optimistic-flip seam, enum-typed.
-        private val writingSurfacePreset = MutableStateFlow(WritingSurfacePreset.SHEET)
+        // FULL_EDITOR mirrors the production default (#951).
+        private val writingSurfacePreset = MutableStateFlow(WritingSurfacePreset.FULL_EDITOR)
         var writingSurfacePresetSetCalls: Int = 0
             private set
         var failOnWritingSurfacePresetSet: Boolean = false

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicScreen.kt
@@ -3610,12 +3610,12 @@ internal enum class WritingSurface { SHEET, FULL_EDITOR }
  * #806 — which surface a write tap opens, from the user's [preset] and the number of citations the
  * tap carries (0 for the reply FAB, 1 for « Citer », the basket size for « Citer N »).
  *
- * - [WritingSurfacePreset.SHEET] (default) keeps the 0.25.1 routing exactly : the quick-reply
- *   sheet, except a multi-quote basket of [MULTI_QUOTE_FULL_EDITOR_THRESHOLD]+ cards (mockup P3 :
- *   « le cas qui force le plein écran », #604 lot 3) — up to that the sheet stays comfortable with
- *   the keyboard open.
+ * - [WritingSurfacePreset.SHEET] (experimental opt-in, #951) keeps the 0.25.1 routing exactly :
+ *   the quick-reply sheet, except a multi-quote basket of [MULTI_QUOTE_FULL_EDITOR_THRESHOLD]+
+ *   cards (mockup P3 : « le cas qui force le plein écran », #604 lot 3) — up to that the sheet
+ *   stays comfortable with the keyboard open.
  * - [WritingSurfacePreset.SHEET_EXCEPT_QUOTES] : any citation (1..N) opens the full-screen editor.
- * - [WritingSurfacePreset.FULL_EDITOR] : always the full-screen editor.
+ * - [WritingSurfacePreset.FULL_EDITOR] (default since #951) : always the full-screen editor.
  *
  * Pure so the routing table is unit-testable ([MultiQuoteRoutingTest]).
  */

--- a/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
+++ b/feature/topic/src/main/kotlin/fr/forumhfr/redface2/feature/topic/TopicUiState.kt
@@ -65,10 +65,10 @@ data class TopicUiState(
      * #806 — mirrors `UserPreferencesRepository.observeWritingSurfacePreset()`. Feeds
      * [writingSurfaceFor] AT TAP TIME on the three write entry points (reply FAB, « Citer »,
      * « Citer N ») to pick the quick-reply sheet or the full-screen editor. Default
-     * [WritingSurfacePreset.SHEET] = the 0.25.1 behaviour. A preset change never migrates an
-     * already-open sheet (the decision is only ever taken on the next tap).
+     * [WritingSurfacePreset.FULL_EDITOR] since the sheet is experimental opt-in (#951). A preset
+     * change never migrates an already-open sheet (the decision is only ever taken on the next tap).
      */
-    val writingSurfacePreset: WritingSurfacePreset = WritingSurfacePreset.SHEET,
+    val writingSurfacePreset: WritingSurfacePreset = WritingSurfacePreset.FULL_EDITOR,
     /**
      * #335 — `true` while a manual pull-to-refresh of the current page is in flight. Drives the
      * Material3 `PullToRefreshBox` spinner. Set on the `Refresh` intent, cleared in the refresh

--- a/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
+++ b/feature/topic/src/test/kotlin/fr/forumhfr/redface2/feature/topic/TopicViewModelTest.kt
@@ -682,7 +682,7 @@ class TopicViewModelTest {
             authRepository = FakeAuthRepository(AuthState.Authenticated("xaat")),
             userPreferencesRepository = FakeUserPreferencesRepository(),
         )
-        assertEquals(WritingSurfacePreset.SHEET, default.state.value.writingSurfacePreset)
+        assertEquals(WritingSurfacePreset.FULL_EDITOR, default.state.value.writingSurfacePreset)
     }
 
     @Test
@@ -3726,8 +3726,9 @@ internal class FakeUserPreferencesRepository(
     private val confirmBeforePosting: Boolean = false,
     // #805 — quote rendering in the composer; false mirrors the production default (inline BBCode).
     private val quoteCardsEnabled: Boolean = false,
-    // #806 — writing-surface preset; SHEET mirrors the production default (0.25.1 behaviour).
-    private val writingSurfacePreset: WritingSurfacePreset = WritingSurfacePreset.SHEET,
+    // #951 — writing-surface preset; FULL_EDITOR mirrors the production default (the
+    // quick-reply sheet is experimental opt-in).
+    private val writingSurfacePreset: WritingSurfacePreset = WritingSurfacePreset.FULL_EDITOR,
 ) : UserPreferencesRepository {
     override fun observeProxyConfig(): Flow<ProxyConfig> = MutableStateFlow(ProxyConfig())
 


### PR DESCRIPTION
> Action par Claude Fable 5 (demandée par @XaaT)

Décision produit (#951) : la feuille de réponse rapide n'est **pas correctement terminée** — elle passe en **expérimental (opt-in)** et le défaut de « Surface d'écriture » (#806) devient **« Toujours plein écran »**.

**Changements** :
- Défaut `WritingSurfacePreset` : `SHEET` → `FULL_EDITOR` aux 3 niveaux — fallback DataStore (flux + lecture défensive valeur corrompue), `TopicUiState`, `SettingsState`. Les presets stockés explicitement sont conservés (aucune migration).
- Réglages : « Toujours la feuille (expérimental) » et « Feuille sauf citations (expérimental) », descriptions préfixées « Expérimental : la feuille n'est pas finalisée » — pattern #805 (Citations en cartes). « Toujours plein écran » marqué (défaut).
- KDoc mis à jour partout (enum, interface repo, TopicScreen routing, TopicUiState).
- Tests : les 3 asserts de défaut basculés (DataStore empty-store + corrupt-value, TopicViewModel, SettingsViewModel), test de revert-sur-échec inversé (soumet SHEET, revert vers FULL_EDITOR), fakes des 5 modules alignés sur le défaut prod.

**Validation** : tests ciblés des 4 modules touchés verts (`--rerun-tasks`, 3m16s), puis commande canonique CI complète verte (7m47s). Le routing feuille/plein écran reste couvert par `MultiQuoteRoutingTest` (table pure inchangée).

Inclut le bump **0.32.0** + entrée `app/CHANGELOG.md` + whatsnew fr/en.

Réf #951 (reste ouverte : point d'ancrage pour re-promouvoir — ou écarter — la feuille).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KszJd7XidCbxgTVedM24W4